### PR TITLE
Add option for outputting devDependancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ simple:
 	> cd your/project/
 	> license-report
 ```
-by default, `license-report` only outputs packages from `dependencies`.
-To include `devDependencies` add `--dev`
+by default, `license-report` outputs all licenses from `dependencies` and `devDependencies`.
+To specify one or the other, use `--only`
 ```
-	> license-report --dev
+	> license-report --only=dev
+```
+```
+	> license-report --only=prod
 ```
 explicit package.json:
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ simple:
 	> cd your/project/
 	> license-report
 ```
+by default, `license-report` only outputs packages from `dependencies`.
+To include `devDependencies` add `--dev`
+```
+	> license-report --dev
+```
 explicit package.json:
 ```
 	license-report --package=/path/to/package.json

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ var devDeps = packageJson.devDependencies
 var depsIndex = []
 
 addAll(deps, depsIndex)
-addAll(devDeps, depsIndex)
+
+if(config.dev)
+	addAll(devDeps, depsIndex)
 
 async.map(depsIndex, getPackageReportData, function(err, results) {
 	if (err) return console.error(err)

--- a/index.js
+++ b/index.js
@@ -29,9 +29,10 @@ var devDeps = packageJson.devDependencies
 */
 var depsIndex = []
 
-addAll(deps, depsIndex)
+if(!config.only || config.only.indexOf('prod') > -1)
+	addAll(deps, depsIndex)
 
-if(config.dev)
+if(!config.only || config.only.indexOf('dev') > -1)
 	addAll(devDeps, depsIndex)
 
 async.map(depsIndex, getPackageReportData, function(err, results) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,9 +15,9 @@ var config = module.exports = rc('license-report', {
 	delimiter: ',',
 
 	/*
-		export dev deps in addition to deps
+		export deps or dev deps. falsey -> output everything
 	*/
-	dev: false,
+	only: null,
 
 	/*
 		npm registry url

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,11 @@ var config = module.exports = rc('license-report', {
 	delimiter: ',',
 
 	/*
+		export dev deps in addition to deps
+	*/
+	dev: false,
+
+	/*
 		npm registry url
 	*/
 	registry: 'https://registry.npmjs.org/',


### PR DESCRIPTION
also make devDeps output false by default

Definite use case for only outputting things from 'deps' since those often end up in outputted code. I made it default because that's how npm works by default — npm only installs devDeps if you pass the `--dev` flag or have the equivalent config.
