### PR TITLE
Added limit option to avoid too many concurrent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # license report tool
 generate license report of a project's dependencies
 
-### install 
+### install
 ```
 	npm install -g license-report
 ```
@@ -35,6 +35,10 @@ customize a default value (only applicable for some fields):
 another registry:
 ```
 	license-report --registry=https://myregistry.com/
+```
+limit number of outgoing requests (if you are getting no output this might help):
+```
+  license-report --limit=5
 ```
 different outputs:
 ```

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ if(!config.only || config.only.indexOf('dev') > -1) {
 	addAll(devDeps, depsIndex)
 }
 
-async.map(depsIndex, getPackageReportData, function(err, results) {
+function reportCallback(err, results) {
 	if (err) return console.error(err)
 
 	if (results.length === 0) return console.log('nothing to do')
@@ -57,7 +57,7 @@ async.map(depsIndex, getPackageReportData, function(err, results) {
 
 				// fill in defaults
 				if (!(fieldName in packageData)) {
-					finalData[fieldName] = config[fieldName].value	
+					finalData[fieldName] = config[fieldName].value
 				}
 			}
 
@@ -90,7 +90,7 @@ async.map(depsIndex, getPackageReportData, function(err, results) {
 				line.fill('-')
 				lines.push(line.toString())
 			}
-			
+
 			results.unshift(lines)
 			results.unshift(labels)
 
@@ -108,15 +108,22 @@ async.map(depsIndex, getPackageReportData, function(err, results) {
 	} catch (e) {
 		console.error(e.stack)
 		process.exit(1)
-	}	
-})
+	}
+}
+
+
+if(!config.limit) {
+  async.map(depsIndex, getPackageReportData, reportCallback)
+} else {
+  async.mapLimit(depsIndex, config.limit, getPackageReportData, reportCallback)
+}
 
 /*
-	add all packages to a package index array. 
+	add all packages to a package index array.
 	maintaining uniqueness (crude methods)
 */
 function addAll(packages, packageIndex) {
-		
+
 	// iterate over packages and prepare urls before I call the registry
 	for (var p in packages) {
 		if(p.indexOf('@') === 0) {
@@ -127,5 +134,5 @@ function addAll(packages, packageIndex) {
 		if (packageIndex.indexOf(package) === -1) {
 			packageIndex.push(package)
 		}
-	}	
+	}
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,7 @@ var config = module.exports = rc('license-report', {
 
 		json || table || csv
 	*/
-	output: 'json', 
+	output: 'json',
 
 	/*
 		if output is csv
@@ -26,8 +26,13 @@ var config = module.exports = rc('license-report', {
 
 	/*
 		an array of package names that will be excluded from the  report
-	*/	
-	exclude: [],
+	*/
+  exclude: [],
+
+  /*
+		limit the number of outgoing to request to avoid deadlocks. falsey -> no limit
+	*/
+  limit: null,
 
 	/*
 		fields participating in the report and their order


### PR DESCRIPTION
Hey, I'm on vacation and my internet connection is not too fast, I tried to run this package and I was getting no output and the program simply hanged, I checked the code and noticed all the request to fetch the packages licenses go out at once, so I added a flag "limit" to limit the amount of concurrent connections.

Let me know what you think.

FYI, I need some help testing the config, I only tested changes in the code not the config, not sure how since test folder does not contain tests for the entire package only for certain files.