### PR TITLE
Fix --exclude flag typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ license-report --output=csv --csvHeaders
 ```
 exclude:
 ```
-license-report --excluse=async --exclude=rc
+license-report --exclude=async --exclude=rc
 ```
 
 ![screenshot](screenshot.png)


### PR DESCRIPTION
Fix an `--exclude` flag that was incorrect misspelled as `--excluse`