### PR TITLE
fix: add support packages without author's name

### DIFF
--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -64,7 +64,7 @@ function getPackageReportData(packageEntry, callback) {
 
 			if (author.url) {
 				if (author.length > 0){
-			  author += ' ';
+			  	author += ' ';
 				}
 				author += author.url;
 			}

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -53,7 +53,7 @@ function getPackageReportData(packageEntry, callback) {
 
 		var author = json.author
 		if (_.isObject(author)) {
-			author = author.name || ""
+			author = author.name || ''
 
 			if (author.email) {
 			  if (author.length > 0) {
@@ -63,7 +63,10 @@ function getPackageReportData(packageEntry, callback) {
 			}
 
 			if (author.url) {
-			  author += "" + author.url;
+				if (author.length > 0){
+			  author += ' ';
+				}
+				author += author.url;
 			}
 		}
 

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -54,13 +54,17 @@ function getPackageReportData(packageEntry, callback) {
 		var author = json.author
 		if (_.isObject(author)) {
 			author = author.name || ""
-			if (author.email) { 
+
+			if (author.email) {
 			  if (author.length > 0) {
 			    author += ' ';
 			  }
 			  author += author.email;
 			}
-			if (author.url) { author = author + ' ' + author.url; }
+
+			if (author.url) {
+			  author += "" + author.url;
+			}
 		}
 
 		callback(null, {

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -51,22 +51,21 @@ function getPackageReportData(packageEntry, callback) {
 
 		var versionData = json.versions[version]
 
-		var author = json.author
-		if (_.isObject(author)) {
-			author = author.name || ''
-
-			if (author.email) {
+		let author = ''
+		if (_.isObject(json.author)) {
+			author = json.author.name || ''
+			if (json.author.email) {
 				if (author.length > 0) {
 					author += ' ';
 				}
-				author += author.email;
+				author += json.author.email;
 			}
 
-			if (author.url) {
+			if (json.author.url) {
 				if (author.length > 0){
 					author += ' ';
 				}
-				author += author.url;
+				author += json.author.url;
 			}
 		}
 

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -54,7 +54,12 @@ function getPackageReportData(packageEntry, callback) {
 		var author = json.author
 		if (_.isObject(author)) {
 			author = author.name || ""
-			if (author.email) { author = author + ' ' + author.email; }
+			if (author.email) { 
+			  if (author.length > 0) {
+			    author += ' ';
+			  }
+			  author += author.email;
+			}
 			if (author.url) { author = author + ' ' + author.url; }
 		}
 

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -56,15 +56,15 @@ function getPackageReportData(packageEntry, callback) {
 			author = author.name || ''
 
 			if (author.email) {
-			  if (author.length > 0) {
-			    author += ' ';
-			  }
-			  author += author.email;
+				if (author.length > 0) {
+					author += ' ';
+				}
+				author += author.email;
 			}
 
 			if (author.url) {
 				if (author.length > 0){
-			  	author += ' ';
+					author += ' ';
 				}
 				author += author.url;
 			}

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -53,7 +53,7 @@ function getPackageReportData(packageEntry, callback) {
 
 		var author = json.author
 		if (_.isObject(author)) {
-			author = author.name;
+			author = author.name || author.email || ""
 			if (author.email) { author = author + ' ' + author.email; }
 			if (author.url) { author = author + ' ' + author.url; }
 		}

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -53,7 +53,7 @@ function getPackageReportData(packageEntry, callback) {
 
 		var author = json.author
 		if (_.isObject(author)) {
-			author = author.name || author.email || ""
+			author = author.name || ""
 			if (author.email) { author = author + ' ' + author.email; }
 			if (author.url) { author = author + ' ' + author.url; }
 		}

--- a/test/getPackageReportData.test.js
+++ b/test/getPackageReportData.test.js
@@ -33,4 +33,38 @@ describe('getPackageReportData', function() {
 			done()
 		})
 	})
+
+	it('return only author name', function(done) {
+		getPackageReportData({ name: 'google-auth-library', fullName: 'google-auth-library', version: '7.0.2' }, function(err, data) {
+			if (err) return done(err)
+			assert.strictEqual(data.author, 'Google Inc.')
+			done()
+		})
+	})
+	it('return only author email', function(done) {
+		getPackageReportData({ name: 'react-hook-form', fullName: 'react-hook-form', version: '6.15.1' }, function(err, data) {
+			if (err) return done(err)
+
+			assert.strictEqual(data.author, 'bluebill1049@hotmail.com')
+			done()
+		})
+	})
+
+	it('return author name with url', function(done) {
+		getPackageReportData({ name: 'knex', fullName: 'knex', version: '0.21.17' }, function(err, data) {
+			if (err) return done(err)
+
+			assert.strictEqual(data.author, 'Tim Griesser https://github.com/tgriesser')
+			done()
+		})
+	})
+
+	it('return author name with email', function(done) {
+		getPackageReportData({ name: 'typeorm', fullName: 'typeorm', version: '0.2.31' }, function(err, data) {
+			if (err) return done(err)
+
+			assert.strictEqual(data.author, 'Umed Khudoiberdiev pleerock.me@gmail.com')
+			done()
+		})
+	})
 })


### PR DESCRIPTION
In projects without author's name i had error:

```
if (author.email) { author = author + ' ' + author.email; }
                                   ^
TypeError: Cannot read property 'email' of undefined
```

With this fix i change to try add name and after add email and after add an empty string.

Example package with this problem:
https://github.com/react-hook-form/react-hook-form