### PR TITLE
Avoid crash when author.name is undefined

### DIFF
--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -53,7 +53,7 @@ function getPackageReportData(packageEntry, callback) {
 
 		var author = json.author
 		if (_.isObject(author)) {
-			author = author.name;
+			author = author.name || {};
 			if (author.email) { author = author + ' ' + author.email; }
 			if (author.url) { author = author + ' ' + author.url; }
 		}


### PR DESCRIPTION
Some libs may not even have an author name, causing this lib to blow up on the next line.

```
❯ yarn generate:licenses
yarn run v1.22.10
$ license-report --output=json
/Users/francocorrea/develop/<project>/node_modules/license-report/lib/getPackageReportData.js:57
                        if (author.email) { author = author + ' ' + author.email; }
                                   ^

TypeError: Cannot read property 'email' of undefined
    at /Users/francocorrea/develop/<project>/node_modules/license-report/lib/getPackageReportData.js:57:15
    at /Users/francocorrea/develop/<project>/node_modules/license-report/lib/getPackageJson.js:22:3
    at Stubborn.p._onTaskExecuted (/Users/francocorrea/develop/<project>/node_modules/stubborn/lib/Stubborn.js:71:18)
    at wrapper (/Users/francocorrea/develop/<project>/node_modules/lodash/lodash.js:4949:19)
    at /Users/francocorrea/develop/<project>/node_modules/lodash/lodash.js:10076:25
    at Request._callback (/Users/francocorrea/develop/<project>/node_modules/license-report/lib/getPackageJson.js:55:11)
    at Request.self.callback (/Users/francocorrea/develop/<project>/node_modules/request/request.js:185:22)
    at Request.emit (node:events:327:20)
    at Request.<anonymous> (/Users/francocorrea/develop/<project>/node_modules/request/request.js:1154:10)
    at Request.emit (node:events:327:20)
error Command failed with exit code 1.

```