### PR TITLE
fix: broken e2e tests due to changed ownership for debug-js

### DIFF
--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -108,7 +108,7 @@ const EXPECTED_RAW_DATA = [
 		definedVersion: '_VERSION_'
 	},
 	{
-		author: 'TJ Holowaychuk tj@vision-media.ca',
+		author: 'Josh Junon josh.junon@protonmail.com',
 		department: 'kessler',
 		relatedTo: 'stuff',
 		name: 'debug',


### PR DESCRIPTION
Author of debug-js has been updated recently, and this causes e2e tests to fail (ran into this while trying to prepare another PR).
See https://github.com/debug-js/debug/commit/19b36c052ab0084f8b1c86d34d3e82190680246a