### PR TITLE
Solve issue #85 - Response Code 404 (Not Found) with local dependencies

### DIFF
--- a/lib/getPackageJson.js
+++ b/lib/getPackageJson.js
@@ -32,5 +32,12 @@ module.exports = async function(name) {
 		options['headers'] = { 'Authorization': `Bearer ${npmToken}` }
 	}
 
-	return await got(uri, options).json()
+	let response = {}
+	try {
+		response = await got(uri, options).json()
+	} catch (error) {
+		debug(`http request to npm for package "${name}" failed with error '${error}'`)
+	}
+
+	return response
 }

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -9,7 +9,7 @@ module.exports = getPackageReportData
 	collect the data for a single package
 */
 async function getPackageReportData(packageEntry, installedPackagesData) {
-	const definedVersion = packageEntry.version
+	let definedVersion = packageEntry.version
 
 	let installedVersion = ''
 	let installedFrom = ''
@@ -24,37 +24,51 @@ async function getPackageReportData(packageEntry, installedPackagesData) {
 		}
 	}
 
-	const fullPackageName = packageEntry.fullName
-	const json = await getPackageJson(fullPackageName)
-
-	// dont think it is possible but just to make sure.
-	if (!json.versions) {
-		throw new Error(`no versions in registry for package ${fullPackageName}`)
-	}
-
-	// find the right remote version for this package
-	let localVersionSemverRange = semver.validRange(packageEntry.version)
-	if (!localVersionSemverRange) {
-		localVersionSemverRange = packageEntry.version
-	}
-
-	const versions = Object.keys(json.versions)
-	let version = semver.maxSatisfying(versions, localVersionSemverRange)
-	if ((version === null) && (json['dist-tags'] !== undefined) && (json['dist-tags'][definedVersion] !== undefined)) {
-		version = json['dist-tags'][definedVersion]
-	}
-
+	let json = {}
+	let version = ''
 	let licenseType = ''
 	let link = ''
-	if (version !== null) {
-		const versionData = json.versions[version]
-		licenseType = extractLicense(versionData)
-		link = extractLink(versionData)
+	let author = ''
+	const fullPackageName = packageEntry.fullName
+
+	// test if this is a locally installed package
+	const linkVersionRegex = /^(http|https|file|git|git\+ssh|git\+https|github):.+/i
+	if (!linkVersionRegex.test(packageEntry.version)) {
+		json = await getPackageJson(fullPackageName)
+
+		// find the right remote version for this package
+		let localVersionSemverRange = semver.validRange(packageEntry.version)
+		if (!localVersionSemverRange) {
+			localVersionSemverRange = packageEntry.version
+		}
+
+		if (json.versions) {
+			const versions = Object.keys(json.versions)
+			version = semver.maxSatisfying(versions, localVersionSemverRange)
+			if ((version === null) && (json['dist-tags'] !== undefined) && (json['dist-tags'][definedVersion] !== undefined)) {
+				version = json['dist-tags'][definedVersion]
+			}
+
+			if (version !== null) {
+				const versionData = json.versions[version]
+				licenseType = extractLicense(versionData)
+				link = extractLink(versionData)
+			} else {
+				version = `no matching version found in registry for package '${toPackageString(packageEntry)}'`
+			}
+		} else {
+			version = `no versions in registry for package ${fullPackageName}`
+		}
 	} else {
-		version = `no matching version found in registry for package '${toPackageString(packageEntry)}'`
+		author = 'n/a'
+		licenseType = 'n/a'
+		link = 'n/a'
+		installedFrom = packageEntry.version
+		version = 'n/a'
+		definedVersion = 'n/a'
+		installedVersion = 'n/a'
 	}
 
-	let author = ''
 	if (isObject(json.author)) {
 		author = json.author.name || ''
 		if (json.author.email) {

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -6,18 +6,6 @@ describe('addPackagesToIndex', function() {
 
 	beforeEach(function() {
 		index = []
-		packages = {
-			"@kessler/exponential-backoff": "^2.0.0",
-			"async": "^0.9.0",
-			"debug": "^3.1.0",
-			"lodash": "^4.17.11",
-			"rc": "^1.2.8",
-			"request": "^2.88.0",
-			"semver": "^5.4.1",
-			"stubborn": "^1.2.5",
-			"text-table": "^0.2.0",
-			"visit-values": "^1.0.1"
-		}
 	})
 
 	it('adds a package to the index', function() {

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -51,11 +51,11 @@ describe('addPackagesToIndex', function() {
 		addPackagesToIndex({ "mocha_8.3.1": "npm:mocha@^8.3.1" }, index)
 
 		assert.deepStrictEqual(index, [{ fullName: 'mocha', name: 'mocha', version: '^8.3.1', scope: undefined, alias: 'mocha_8.3.1' }])
-	});
+	})
 
 	it('add scoped package with alias to the index', function() {
 		addPackagesToIndex({ "@kessler/tableify_1.0.1": "npm:@kessler/tableify@^1.0.1" }, index)
 
 		assert.deepStrictEqual(index, [{ fullName: '@kessler/tableify', name: 'tableify', version: '^1.0.1', scope: 'kessler', alias: '@kessler/tableify_1.0.1' }])
-	});
+	})
 })

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -20,6 +20,12 @@ describe('addPackagesToIndex', function() {
 		assert.deepStrictEqual(index, [{ fullName: '@bar/foo', name: 'foo', version: '*', scope: 'bar', alias: '' }])
 	})
 
+	it('adds a local package to the index', function() {
+		addPackagesToIndex({ "my-local-package": "file:local-libs/my-local-package" }, index)
+
+		assert.deepStrictEqual(index, [{ fullName: 'my-local-package', name: 'my-local-package', version: 'file:local-libs/my-local-package', scope: undefined, alias: '' }])
+	})
+
 	it('does not add duplicate packages, same package is a package that has the same name, version expression and scope', function() {
 		addPackagesToIndex({ "@bar/foo": "*" }, index)
 		addPackagesToIndex({ "@bar/foo": "*" }, index)

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -1,5 +1,5 @@
 const cp = require('child_process')
-const util = require('util');
+const util = require('util')
 const path = require('path')
 const assert = require('assert')
 const fs = require('fs')
@@ -32,7 +32,7 @@ const allFieldsConfigPath = path
 	.resolve(__dirname, 'fixture', 'all-supported-fields', 'license-report-config.json')
 	.replace(/(\s+)/g, '\\$1')
 
-const execAsPromise = util.promisify(cp.exec);
+const execAsPromise = util.promisify(cp.exec)
 
 let expectedData
 
@@ -99,7 +99,7 @@ describe('end to end test for configuration', function () {
 
 		assert.deepStrictEqual(result, expectedResult, `expected the output to contain all the configured fields`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
-	});
+	})
 
 	it('produce a json report without option "only"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath}`)
@@ -108,7 +108,7 @@ describe('end to end test for configuration', function () {
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
-	});
+	})
 
 	it('produce a json report with option "only=prod"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --only=prod`)
@@ -117,7 +117,7 @@ describe('end to end test for configuration', function () {
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
-	});
+	})
 
 	it('produce a json report with option "only=prod,opt,peer"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --only=prod,opt,peer`)
@@ -126,8 +126,8 @@ describe('end to end test for configuration', function () {
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
-	});
-});
+	})
+})
 
 // raw data we use to generate the expected results
 const EXPECTED_DEFAULT_FIELDS_RAW_DATA = [

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -10,6 +10,7 @@ const scriptPath = path
 	.resolve(__dirname, '..', 'index.js')
 	.replace(/(\s+)/g, '\\$1')
 
+// test data for e2e test using the default fields
 const defaultFieldsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'default-fields', 'package.json')
 	.replace(/(\s+)/g, '\\$1')
@@ -18,7 +19,8 @@ const defaultFieldsPackageLockJsonPath = path
 	.replace(/(\s+)/g, '\\$1')	
 const defaultFieldsPackageJson = require(defaultFieldsPackageJsonPath)
 const defaultFieldsPackageLockJson = require(defaultFieldsPackageLockJsonPath)
-	
+
+// test data for e2e test using all fields
 const allFieldsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'all-supported-fields', 'package.json')
 	.replace(/(\s+)/g, '\\$1')	
@@ -27,9 +29,21 @@ const allFieldsPackageLockJsonPath = path
 	.replace(/(\s+)/g, '\\$1')	
 const allFieldsPackageJson = require(allFieldsPackageJsonPath)
 const allFieldsPackageLockJson = require(allFieldsPackageLockJsonPath)
-
 const allFieldsConfigPath = path
 	.resolve(__dirname, 'fixture', 'all-supported-fields', 'license-report-config.json')
+	.replace(/(\s+)/g, '\\$1')
+
+// test data for e2e test using the default fields and local packages
+const localPackagesPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'local-packages', 'package.json')
+	.replace(/(\s+)/g, '\\$1')
+const localPackagesPackageLockJsonPath = path
+	.resolve(__dirname, 'fixture', 'local-packages', 'package-lock.json')
+	.replace(/(\s+)/g, '\\$1')
+const localPackagesPackageJson = require(localPackagesPackageJsonPath)
+const localPackagesPackageLockJson = require(localPackagesPackageLockJsonPath)
+const localPackagesConfigPath = path
+	.resolve(__dirname, 'fixture', 'local-packages', 'license-report-config.json')
 	.replace(/(\s+)/g, '\\$1')
 
 const execAsPromise = util.promisify(cp.exec)
@@ -73,6 +87,23 @@ describe('end to end test', function() {
 		const expectedHtmlResult = expectedOutput.rawDataToHtml(expectedData, expectedHtmlTemplate)
 
 		assert.strictEqual(actualResult, expectedHtmlResult)
+	})
+})
+
+describe('end to end test for local packages', function() {
+	this.timeout(50000)
+
+	beforeEach(async  () => {
+		expectedData = EXPECTED_LOCAL_PACKAGES_RAW_DATA.slice(0)
+		await expectedOutput.addInstalledAndRemoteVersionsToExpectedData(expectedData, localPackagesPackageJson, localPackagesPackageLockJson)
+  })
+
+	it('produce a json report', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${localPackagesPackageJsonPath} --config=${localPackagesConfigPath}`)
+		const result = JSON.parse(stdout)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+
+		assert.deepStrictEqual(result, expectedJsonResult)
 	})
 })
 
@@ -129,7 +160,7 @@ describe('end to end test for configuration', function () {
 	})
 })
 
-// raw data we use to generate the expected results
+// raw data we use to generate the expected results for default fields test
 const EXPECTED_DEFAULT_FIELDS_RAW_DATA = [
 	{
 		author: 'Dan VerWeire, Yaniv Kessler',
@@ -182,6 +213,66 @@ const EXPECTED_DEFAULT_FIELDS_RAW_DATA = [
 		remoteVersion: '_VERSION_',
 		installedVersion: '_VERSION_',
 		definedVersion: '^7.3.5'
+	},	
+]
+
+// raw data we use to generate the expected results for default fields test
+const EXPECTED_LOCAL_PACKAGES_RAW_DATA = [
+	{
+		author: 'n/a',
+		department: 'kessler',
+		relatedTo: 'stuff',
+		name: 'async',
+		licensePeriod: 'perpetual',
+		material: 'material',
+		licenseType: 'n/a',
+		link: 'n/a',
+    installedFrom: "github:caolan/async",
+		remoteVersion: 'n/a',
+		installedVersion: 'n/a',
+		definedVersion: 'n/a'
+	},
+	{
+		author: 'GitHub Inc.',
+		department: 'kessler',
+		relatedTo: 'stuff',
+		name: 'semver',
+		licensePeriod: 'perpetual',
+		material: 'material',
+		licenseType: 'ISC',
+		link: 'git+https://github.com/npm/node-semver.git',
+    installedFrom: "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+		remoteVersion: '_VERSION_',
+		installedVersion: '_VERSION_',
+		definedVersion: '^7.3.7'
+	},
+	{
+		author: "n/a",
+		department: 'kessler',
+		relatedTo: 'stuff',
+		name: 'debug',
+		licensePeriod: 'perpetual',
+		material: 'material',
+		licenseType: 'n/a',
+		link: 'n/a',
+    installedFrom: "git://github.com/debug-js/debug.git",
+		remoteVersion: 'n/a',
+		installedVersion: 'n/a',
+		definedVersion: 'n/a'
+	},	
+	{
+		author: 'n/a',
+		department: 'kessler',
+		relatedTo: 'stuff',
+		name: 'my-local-package',
+		licensePeriod: 'perpetual',
+		material: 'material',
+		licenseType: 'n/a',
+		link: 'n/a',
+    installedFrom: "file:local-libs/my-local-package",
+		remoteVersion: 'n/a',
+		installedVersion: 'n/a',
+		definedVersion: 'n/a'
 	},	
 ]
 

--- a/test/fixture/all-supported-fields/license-report-config.json
+++ b/test/fixture/all-supported-fields/license-report-config.json
@@ -1,15 +1,15 @@
 {
     "fields": [
-        "department",
-		"relatedTo",
-		"name",
-		"licensePeriod",
-		"material",
-		"licenseType",
-		"link",
-		"remoteVersion",
-		"installedVersion",
-		"definedVersion",
-		"author"
+			"department",
+			"relatedTo",
+			"name",
+			"licensePeriod",
+			"material",
+			"licenseType",
+			"link",
+			"remoteVersion",
+			"installedVersion",
+			"definedVersion",
+			"author"
     ]
 }

--- a/test/fixture/local-packages/license-report-config.json
+++ b/test/fixture/local-packages/license-report-config.json
@@ -1,0 +1,16 @@
+{
+    "fields": [
+			"department",
+			"relatedTo",
+			"name",
+			"licensePeriod",
+			"material",
+			"licenseType",
+			"link",
+			"installedFrom",
+			"remoteVersion",
+			"installedVersion",
+			"definedVersion",
+			"author"
+    ]
+}

--- a/test/fixture/local-packages/package-lock.json
+++ b/test/fixture/local-packages/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "license-report",
+  "requires": true,
+  "lockfileVersion": 2,
+  "dependencies": {
+    "async": {
+      "version": "git+ssh://git@github.com/caolan/async.git#6d68b63aecd37d98f836d29d2089010e30c3e3d3",
+      "from": "async@github:caolan/async"
+    },
+    "debug": {
+      "version": "git+ssh://git@github.com/debug-js/debug.git#d1616622e4d404863c5a98443f755b4006e971dc",
+      "dev": true,
+      "from": "debug@git://github.com/debug-js/debug.git",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "my-local-package": {
+      "version": "file:local-libs/my-local-package"
+    },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/test/fixture/local-packages/package.json
+++ b/test/fixture/local-packages/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "license-report",
+  "description": "package.json for e2e tests",
+  "dependencies": {
+    "async": "github:caolan/async",
+    "semver": "^7.3.7"
+  },
+  "devDependencies": {
+    "debug": "git://github.com/debug-js/debug.git",
+    "my-local-package": "file:local-libs/my-local-package"
+  }
+}

--- a/test/getInstalledPackagesData.test.js
+++ b/test/getInstalledPackagesData.test.js
@@ -9,7 +9,7 @@ describe('getInstalledPackagesData', () => {
 
 		assert.strictEqual(installedPackagesData['mocha'].version, '6.2.3')
     assert.strictEqual(installedPackagesData['mocha'].installedFrom, 'https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz')
-  });
+  })
 
   it('gets versions with prebuild package', () => {
     const packageLockContent = { dependencies: { ol: { version: '6.5.1-dev.1622493276948' } } }
@@ -17,7 +17,7 @@ describe('getInstalledPackagesData', () => {
 		const installedPackagesData = getInstalledPackagesData(packageLockContent, depsIndex)
 
 		assert.strictEqual(installedPackagesData['ol'].version, '6.5.1-dev.1622493276948')
-  });
+  })
 
   it('gets versions with alias package', () => {
     const packageLockContent = { dependencies: { 'mocha_8.3.1': { version: 'npm:mocha@8.4.0' } } }
@@ -25,5 +25,5 @@ describe('getInstalledPackagesData', () => {
 		const installedPackagesData = getInstalledPackagesData(packageLockContent, depsIndex)
 
 		assert.strictEqual(installedPackagesData['mocha_8.3.1'].version, 'npm:mocha@8.4.0')
-  });
-});
+  })
+})

--- a/test/getInstalledPackagesData.test.js
+++ b/test/getInstalledPackagesData.test.js
@@ -11,6 +11,14 @@ describe('getInstalledPackagesData', () => {
     assert.strictEqual(installedPackagesData['mocha'].installedFrom, 'https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz')
   })
 
+  it('gets the package data for local package', () => {
+    const packageLockContent = { dependencies: { 'my-local-package': { version: 'file:local-libs/my-local-package' } } }
+    const depsIndex = [{ name: 'my-local-package', fullName: 'my-local-package', version: 'file:local-libs/my-local-package' }]
+		const installedPackagesData = getInstalledPackagesData(packageLockContent, depsIndex)
+
+		assert.strictEqual(installedPackagesData['my-local-package'].version, 'file:local-libs/my-local-package')
+  })
+
   it('gets versions with prebuild package', () => {
     const packageLockContent = { dependencies: { ol: { version: '6.5.1-dev.1622493276948' } } }
     const depsIndex = [{ name: 'ol', fullName: 'ol', version: 'dev' }]

--- a/test/getPackageJson.test.js
+++ b/test/getPackageJson.test.js
@@ -7,14 +7,8 @@ describe('getPackageJson', () => {
     assert.strictEqual(packageJson.homepage, 'https://github.com/npm/node-semver#readme')
   })
 
-  it('throws on getting information about non existing package', async () => {
-    await assert.rejects(
-      getPackageJson('packagedoesnotexist'),
-      (err) => {
-        assert.strictEqual(err.name, 'HTTPError')
-        assert.strictEqual(err.message, 'Response code 404 (Not Found)')
-        return true
-      }
-    )
+  it('gets empty object for non existing package', async () => {
+    const packageJson = await getPackageJson('packagedoesnotexist')
+    assert.deepEqual(packageJson, {})
   })
 })

--- a/test/getPackageReportData.test.js
+++ b/test/getPackageReportData.test.js
@@ -163,7 +163,7 @@ describe('getPackageReportData', function() {
 		assert.strictEqual(packageReportData.link, 'git+https://github.com/mochajs/mocha.git')
 		assert.strictEqual(packageReportData.definedVersion, '^8.3.1', 'definedVersion')
 		assert.strictEqual(packageReportData.installedVersion, '8.3.1', 'installedVersion')
-	});
+	})
 
 	it('gets report data for package with installed from', async () => {
 		const installedPackagesData = { '@angular/core': { version: '13.3.0', installedFrom: 'https://registry.npmjs.org/@angular/core/-/core-13.3.0.tgz' } }
@@ -174,5 +174,5 @@ describe('getPackageReportData', function() {
 		assert.strictEqual(packageReportData.definedVersion, '^13.0.0', 'definedVersion')
 		assert.strictEqual(packageReportData.installedVersion, '13.3.0', 'installedVersion')
 		assert.strictEqual(packageReportData.installedFrom, 'https://registry.npmjs.org/@angular/core/-/core-13.3.0.tgz', 'installedFrom')
-	});	
+	})
 })

--- a/test/getPackageReportData.test.js
+++ b/test/getPackageReportData.test.js
@@ -175,4 +175,49 @@ describe('getPackageReportData', function() {
 		assert.strictEqual(packageReportData.installedVersion, '13.3.0', 'installedVersion')
 		assert.strictEqual(packageReportData.installedFrom, 'https://registry.npmjs.org/@angular/core/-/core-13.3.0.tgz', 'installedFrom')
 	})
+
+	it('gets report data for local package using "file:"', async () => {
+		const installedPackagesData = { 'my-local-package': { version: 'file:local-libs/my-local-package' } }
+		const packageEntry = { fullName: 'my-local-package', name: 'my-local-package', version: 'file:local-libs/my-local-package', scope: undefined, alias: '' }
+		const packageReportData = await getPackageReportData(packageEntry, installedPackagesData)
+
+		assert.strictEqual(packageReportData.name, 'my-local-package')
+		assert.strictEqual(packageReportData.author, 'n/a')
+		assert.strictEqual(packageReportData.licenseType, 'n/a')
+		assert.strictEqual(packageReportData.link, 'n/a')
+		assert.strictEqual(packageReportData.installedFrom, 'file:local-libs/my-local-package')
+		assert.strictEqual(packageReportData.definedVersion, 'n/a')
+		assert.strictEqual(packageReportData.installedVersion, 'n/a')
+		assert.strictEqual(packageReportData.remoteVersion, 'n/a')
+	})
+
+	it('gets report data for local package using "git:"', async () => {
+		const installedPackagesData = { 'debug': { version: 'git://github.com/debug-js/debug.git' } }
+		const packageEntry = { fullName: 'debug', name: 'debug', version: 'git://github.com/debug-js/debug.git', scope: undefined, alias: '' }
+		const packageReportData = await getPackageReportData(packageEntry, installedPackagesData)
+
+		assert.strictEqual(packageReportData.name, 'debug')
+		assert.strictEqual(packageReportData.author, 'n/a')
+		assert.strictEqual(packageReportData.licenseType, 'n/a')
+		assert.strictEqual(packageReportData.link, 'n/a')
+		assert.strictEqual(packageReportData.installedFrom, 'git://github.com/debug-js/debug.git')
+		assert.strictEqual(packageReportData.definedVersion, 'n/a')
+		assert.strictEqual(packageReportData.installedVersion, 'n/a')
+		assert.strictEqual(packageReportData.remoteVersion, 'n/a')
+	})
+
+	it('gets report data for local package using "github:"', async () => {
+		const installedPackagesData = { 'async': { version: 'github:caolan/async' } }
+		const packageEntry = { fullName: 'async', name: 'async', version: 'github:caolan/async', scope: undefined, alias: '' }
+		const packageReportData = await getPackageReportData(packageEntry, installedPackagesData)
+
+		assert.strictEqual(packageReportData.name, 'async')
+		assert.strictEqual(packageReportData.author, 'n/a')
+		assert.strictEqual(packageReportData.licenseType, 'n/a')
+		assert.strictEqual(packageReportData.link, 'n/a')
+		assert.strictEqual(packageReportData.installedFrom, 'github:caolan/async')
+		assert.strictEqual(packageReportData.definedVersion, 'n/a')
+		assert.strictEqual(packageReportData.installedVersion, 'n/a')
+		assert.strictEqual(packageReportData.remoteVersion, 'n/a')
+	})
 })

--- a/test/privateRepository.test.js
+++ b/test/privateRepository.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const nock = require('nock');
+const nock = require('nock')
 const config = require('../lib/config')
 const getPackageJson = require('../lib/getPackageJson')
 
@@ -14,14 +14,14 @@ describe('private repository access test', function() {
 		originalConfigRegistry = config.registry
 		originalConfigNpmTokenEnvVar = config.npmTokenEnvVar
 		originalHttpRetry = config.httpRetryOptions.maxAttempts
-  });
+  })
 
   afterEach(function() {
 		config.registry = originalConfigRegistry
 		config.npmTokenEnvVar = originalConfigNpmTokenEnvVar
 		config.httpRetryOptions.maxAttempts = originalHttpRetry
 		nock.cleanAll()
-  });
+  })
 
 	it('get npm token indirect from config', function() {
 		const envVarName = 'TEST_NPM_TOKEN_LR'
@@ -47,7 +47,7 @@ describe('private repository access test', function() {
 		// Mock the npm private repository response
 		const scope = nock(npmRegistry, {"encodedQueryParams":true})
 	  .get(`/${packageName}`)
-	  .reply(200, responses.async);
+	  .reply(200, responses.async)
 
 		const packageReportData = await getPackageJson(packageName)
 
@@ -73,7 +73,7 @@ describe('private repository access test', function() {
 	  .matchHeader("host", npmRegistryHost)
 	  .matchHeader("authorization", `Bearer ${npmToken}`)
 	  .get(`/${packageName}`)
-	  .reply(200, responses.async);
+	  .reply(200, responses.async)
 
 		const packageReportData = await getPackageJson('async')
 
@@ -99,7 +99,7 @@ describe('private repository access test', function() {
 	  .matchHeader("host", npmRegistryHost)
 	  .matchHeader("authorization", `Bearer ${npmToken}`)
 	  .get(`/${packageName}`)
-	  .reply(401, {});
+	  .reply(401, {})
 
 		try {
 			const packageReportData = await getPackageJson('async')


### PR DESCRIPTION
Activating the debug mode shows that license-report throws a http error 404 when trying to get information about a locally installed package (e.g. with 'file:...') from the registry (as a locally installed package has no corresponding package in the registry).

Now license-report sets the corresponding fields (e.g. `remoteVersion` to 'n/a).