### PR TITLE
fix: issue 91: update 'got' to v12 (latest version)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,3 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "got"
-      versions: ["12.x"]

--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
 
-const fs = require('fs')
-const path = require('path')
-const debug = require('debug')('license-report')
-const config = require('./lib/config.js')
-const getFormatter = require('./lib/getFormatter')
-const addLocalPackageData = require('./lib/addLocalPackageData')
-const addPackagesToIndex = require('./lib/addPackagesToIndex')
-const addPackageDataFromRepository = require('./lib/addPackageDataFromRepository.js')
-const packageDataToReportData = require('./lib/packageDataToReportData')
-const util = require('./lib/util');
+import fs from 'node:fs';
+import path from 'node:path';
+import createDebugMessages from 'debug';
+import config from './lib/config.js';
+import getFormatter from './lib/getFormatter.js';
+import addLocalPackageData from './lib/addLocalPackageData.js';
+import addPackagesToIndex from './lib/addPackagesToIndex.js';
+import addPackageDataFromRepository from './lib/addPackageDataFromRepository.js';
+import packageDataToReportData from './lib/packageDataToReportData.js';
+import { helpText, readJson } from './lib/util.js';
+
+const debug = createDebugMessages('license-report');
 
 (async () => {
   if (config.help) {
-    console.log(util.helpText)
+    console.log(helpText)
     return
   }
 
@@ -33,7 +35,7 @@ const util = require('./lib/util');
     debug('loading %s', resolvedPackageJson)
     let packageJson
     if (fs.existsSync(resolvedPackageJson)) {
-      packageJson = await util.readJson(resolvedPackageJson)
+      packageJson = await readJson(resolvedPackageJson)
     } else {
       throw new Error(`Warning: the file '${resolvedPackageJson}' is required to get installed versions of packages`)
     }

--- a/lib/addLocalPackageData.js
+++ b/lib/addLocalPackageData.js
@@ -1,11 +1,11 @@
-const fs = require('fs')
-const path = require('path')
-const debug = require('debug')('license-report:addLocalPackageData')
-const util = require('./util');
-const extractAuthor = require('./extractAuthor.js')
-const extractLicense = require('./extractLicense.js')
+import fs from 'node:fs';
+import path from 'node:path';
+import createDebugMessages from 'debug';
+import { readJson } from './util.js';
+import extractAuthor from './extractAuthor.js';
+import extractLicense from './extractLicense.js';
 
-module.exports = addLocalPackageData
+const debug = createDebugMessages('license-report:addLocalPackageData');
 
 /**
  * Extracts information about a package from the corresponding package.json file
@@ -25,7 +25,7 @@ module.exports = addLocalPackageData
   }
   const elementPackageJsonPath = path.join(projectRootPath, 'node_modules', packageFolderName, 'package.json')
   if (fs.existsSync(elementPackageJsonPath)) {
-    const packageJSONContent = await util.readJson(elementPackageJsonPath)
+    const packageJSONContent = await readJson(elementPackageJsonPath)
     if ((packageJSONContent !== undefined) && (packageJSONContent.version !== undefined)) {
       element['installedVersion'] = packageJSONContent.version
     } else {
@@ -44,3 +44,5 @@ module.exports = addLocalPackageData
 
   return element
 }
+
+export default addLocalPackageData;

--- a/lib/addPackageDataFromRepository.js
+++ b/lib/addPackageDataFromRepository.js
@@ -1,10 +1,7 @@
-const semver = require('semver')
-const getPackageDataFromRepository = require('./getPackageDataFromRepository.js')
-const extractLink = require('./extractLink.js')
-const extractLicense = require('./extractLicense.js')
-const extractInstalledFrom = require('./extractInstalledFrom.js')
-
-module.exports = addPackageDataFromRepository
+import semver from 'semver';
+import getPackageDataFromRepository from './getPackageDataFromRepository.js';
+import extractLink from './extractLink.js';
+import extractInstalledFrom from './extractInstalledFrom.js';
 
 /**
  * Collects the data for a single package (link, installedFrom, remoteVersion)
@@ -94,3 +91,5 @@ async function addPackageDataFromRepository(packageEntry) {
 function toPackageString(entry) {
 	return entry.fullName + '@' + entry.version
 }
+
+export default addPackageDataFromRepository;

--- a/lib/addPackagesToIndex.js
+++ b/lib/addPackagesToIndex.js
@@ -1,9 +1,3 @@
-/*
-	add all packages to a package index array. 
-	maintaining uniqueness (crudely)
-*/
-module.exports = addPackagesToIndex
-
 /**
  * Add all packages to a package index array maintaining uniqueness (crudely)
  * @param {object} packages - element from package.json (e.g. 'dependencies' or 'devDependencies')
@@ -54,3 +48,5 @@ function addPackagesToIndex(packages, packageIndex, exclusions) {
 		}
 	}
 }
+
+export default addPackagesToIndex;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,10 @@
-const rc = require('rc')
-const path = require('path')
+import path from 'node:path';
+import url from 'node:url';
+import rc from 'rc';
 
-module.exports = rc('license-report', {
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
+export default rc('license-report', {
 	/*
 		possible outputs:
 
@@ -122,7 +124,7 @@ module.exports = rc('license-report', {
 		label: 'comment'
 	},
 	httpRetryOptions: {
-		maxAttempts: 5
+		limit: 5
 	},
 	httpTimeoutOptions: {
 		request: 30000

--- a/lib/extractAuthor.js
+++ b/lib/extractAuthor.js
@@ -1,5 +1,3 @@
-module.exports = extractAuthor
-
 /**
  * Extract author from content of a package.json file
  * @param {object} packageJSONContent - content of package.json for 1 package
@@ -34,3 +32,5 @@ function extractAuthor(packageJSONContent) {
 function isObject(element) {
 	return ((element !== null) && ((typeof element === "object") || (typeof element === 'function')))
 }
+
+export default extractAuthor;

--- a/lib/extractInstalledFrom.js
+++ b/lib/extractInstalledFrom.js
@@ -1,5 +1,3 @@
-module.exports = extractInstalledFrom
-
 /**
  * Extract installation source file from registry data for a package
  * @param {object} json - object fetched from registry with information about 1 package
@@ -10,3 +8,5 @@ function extractInstalledFrom(json) {
 		return json.dist.tarball
 	}
 }
+
+export default extractInstalledFrom;

--- a/lib/extractLicense.js
+++ b/lib/extractLicense.js
@@ -1,5 +1,3 @@
-module.exports = extractLicense
-
 /**
  * Extract license type from content of a package.json file
  * @param {object} packageJSONContent - content of package.json for 1 package
@@ -37,3 +35,5 @@ function extractLicense(packageJSONContent) {
 	}
 	return licenseType
 }
+
+export default extractLicense;

--- a/lib/extractLink.js
+++ b/lib/extractLink.js
@@ -1,6 +1,4 @@
-const visit = require('visit-values')
-
-module.exports = extractLink
+import visit from 'visit-values';
 
 /**
  * Extract link to repository from registry data for a package
@@ -32,3 +30,5 @@ function extractLink(json) {
 		return otherUrls[0]
 	}
 }
+
+export default extractLink;

--- a/lib/getFormatter.js
+++ b/lib/getFormatter.js
@@ -1,8 +1,6 @@
-const table = require('text-table')
-const tableify = require('@kessler/tableify')
-const fs = require('fs')
-
-module.exports = getFormatter
+import fs from 'node:fs';
+import table from 'text-table';
+import tableify from '@kessler/tableify';
 
 /**
  * Formats package information as json string.
@@ -62,8 +60,8 @@ function formatAsCsv(dataAsArray, config) {
 	}
 
 	for (const element of data) {
-		validatedFields = element.map(fieldValue => {
-			validatedField = fieldValue
+		const validatedFields = element.map(fieldValue => {
+			let validatedField = fieldValue
 			if (fieldValue.includes(delimiter)) {
 				console.warn(`Warning: field contains delimiter; value: "${fieldValue}"`)
 				if (escapeFields) {
@@ -183,3 +181,5 @@ function dataArrayWithEmptyRow(config) {
 	}
 	return emptyRow
 }
+
+export default getFormatter;

--- a/lib/getPackageDataFromRepository.js
+++ b/lib/getPackageDataFromRepository.js
@@ -1,8 +1,8 @@
-const got = require('got')
-const debug = require('debug')('license-report:getPackageDataFromRepository')
-const config = require('./config.js')
+import got from 'got';
+import createDebugMessages from 'debug';
+import config from './config.js';
 
-module.exports = getPackageDataFromRepository
+const debug = createDebugMessages('license-report:getPackageDataFromRepository');
 
 /**
  * Fetch the information about 1 package from the npm registry
@@ -15,11 +15,11 @@ async function getPackageDataFromRepository(name) {
 	debug('getPackageDataFromRepository - REQUEST %s', uri)
 
 	const options = {
-		retry: config.httpRetryOptions.maxAttempts,
+		retry: config.httpRetryOptions,
 		timeout: config.httpTimeoutOptions,
 		hooks: {
 			beforeRetry: [
-				(options, error, retryCount) => {
+				(error, retryCount) => {
 					debug(`http request to npm for package "${name}" failed, retrying again soon...`)
 				}
 			],
@@ -49,3 +49,5 @@ async function getPackageDataFromRepository(name) {
 
 	return response
 }
+
+export default getPackageDataFromRepository;

--- a/lib/packageDataToReportData.js
+++ b/lib/packageDataToReportData.js
@@ -1,5 +1,3 @@
-module.exports = packageDataToReportData
-
 /**
  * Create object with all fields listed in config.fields with current values about one package.
  * Only fields from field list will be returned in generated object.
@@ -21,3 +19,5 @@ function packageDataToReportData(packageData, config) {
 
 	return finalData
 }
+
+export default packageDataToReportData;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,4 @@
-const fs = require('fs')
-
-exports.readJson = readJson
+import fs from 'node:fs';
 
 /**
  * Get an object by asynchronously reading a file
@@ -12,7 +10,7 @@ exports.readJson = readJson
   return JSON.parse(data)
 }
 
-exports.helpText = `Generate a detailed report of the licenses of all projects dependencies.
+const helpText = `Generate a detailed report of the licenses of all projects dependencies.
 
 Usage: license-report [options]
 
@@ -40,3 +38,9 @@ Options:
   --<field>.value=<new-value>           Set value for static output field. Allowed field names are:
                                         department, relatedTo, licensePeriod, material.
 `
+
+// TODO export default ... (unt an Verwendungsstellen import util und util.xyz)
+export {
+  readJson,
+  helpText
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@kessler/tableify": "^1.0.2",
         "debug": "^4.3.4",
         "eol": "^0.9.1",
-        "got": "^11.8.5",
+        "got": "^12.1.0",
         "rc": "^1.2.8",
         "semver": "^7.3.7",
         "text-table": "^0.2.0",
@@ -440,14 +440,14 @@
       }
     },
     "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dependencies": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -705,9 +705,9 @@
       "dev": true
     },
     "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
+      "integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -1768,6 +1768,11 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -1897,7 +1902,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2038,27 +2042,40 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
+      "integrity": "sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==",
       "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
+        "@sindresorhus/is": "^4.6.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "@types/cacheable-request": "^6.0.2",
         "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
+        "cacheable-lookup": "^6.0.4",
         "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
+        "form-data-encoder": "1.7.1",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
         "responselike": "^2.0.0"
       },
       "engines": {
-        "node": ">=10.19.0"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -2145,12 +2162,12 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
+      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
       "dependencies": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       },
       "engines": {
         "node": ">=10.19.0"
@@ -2890,11 +2907,11 @@
       }
     },
     "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -4425,11 +4442,11 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "requires": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       }
     },
     "@tsconfig/node10": {
@@ -4650,9 +4667,9 @@
       "dev": true
     },
     "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
+      "integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A=="
     },
     "cacheable-request": {
       "version": "7.0.2",
@@ -5456,6 +5473,11 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
     },
+    "form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
     "fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5564,8 +5586,7 @@
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "git-raw-commits": {
       "version": "2.0.11",
@@ -5671,21 +5692,30 @@
       }
     },
     "got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.1.0.tgz",
+      "integrity": "sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==",
       "requires": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
+        "@sindresorhus/is": "^4.6.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "@types/cacheable-request": "^6.0.2",
         "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
+        "cacheable-lookup": "^6.0.4",
         "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
+        "form-data-encoder": "1.7.1",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
         "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+          "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="
+        }
       }
     },
     "graceful-fs": {
@@ -5749,12 +5779,12 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
+      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
       "requires": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       }
     },
     "human-signals": {
@@ -6307,9 +6337,9 @@
       }
     },
     "p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="
     },
     "p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bin": {
     "license-report": "index.js"
   },
+  "type":"module",
   "repository": {
     "type": "git",
     "url": "https://github.com/ironSource/license-report"
@@ -26,7 +27,7 @@
     "@kessler/tableify": "^1.0.2",
     "debug": "^4.3.4",
     "eol": "^0.9.1",
-    "got": "^11.8.5",
+    "got": "^12.1.0",
     "rc": "^1.2.8",
     "semver": "^7.3.7",
     "text-table": "^0.2.0",
@@ -41,6 +42,6 @@
     "standard-version": "^9.5.0"
   },
   "engines": {
-    "node": ">=7.6"
+    "node": ">=14"
   }
 }

--- a/test/addLocalPackageData.test.js
+++ b/test/addLocalPackageData.test.js
@@ -1,6 +1,9 @@
-const assert = require('assert')
-const path = require('path')
-const addLocalPackageData = require('../lib/addLocalPackageData.js')
+import assert from 'node:assert';
+import path from 'node:path';
+import url from 'node:url';
+import addLocalPackageData from '../lib/addLocalPackageData.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 describe('addLocalPackageData', function() {
   let projectRootPath

--- a/test/addPackageDataFromRepository.test.js
+++ b/test/addPackageDataFromRepository.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const nock = require('nock')
-const config = require('../lib/config')
-const addPackageDataFromRepository = require('../lib/addPackageDataFromRepository.js')
+import assert from 'node:assert';
+import nock from 'nock';
+import config from '../lib/config.js';
+import addPackageDataFromRepository from '../lib/addPackageDataFromRepository.js';
 
 /**
  * Fetching data from the repository gets mocked to get independent from
@@ -10,14 +10,14 @@ const addPackageDataFromRepository = require('../lib/addPackageDataFromRepositor
 describe('addPackageDataFromRepository', function() {
 	this.timeout(20000)
 
-	let originalHttpRetry
+	let originalHttpRetryLimit
 
 	beforeEach(function() {
-		originalHttpRetry = config.httpRetryOptions.maxAttempts
+		originalHttpRetryLimit = config.httpRetryOptions.limit
   })
 
   afterEach(function() {
-		config.httpRetryOptions.maxAttempts = originalHttpRetry
+		config.httpRetryOptions.limit = originalHttpRetryLimit
 		nock.cleanAll()
   })
 
@@ -32,7 +32,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -59,7 +59,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -84,7 +84,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -109,7 +109,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -134,7 +134,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -160,7 +160,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])
@@ -186,7 +186,7 @@ describe('addPackageDataFromRepository', function() {
 		}
 
 		// Mock the npm repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageEntry.fullName}`)
 	  .reply(200, responses[packageEntry.fullName])

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const addPackagesToIndex = require('../lib/addPackagesToIndex.js')
+import assert from 'node:assert';
+import addPackagesToIndex from '../lib/addPackagesToIndex.js';
 
 describe('addPackagesToIndex', function() {
 	let index

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -1,10 +1,13 @@
-const cp = require('child_process')
-const util = require('util')
-const path = require('path')
-const assert = require('assert')
-const fs = require('fs')
-const eol = require('eol')
-const expectedOutput = require('./fixture/expectedOutput.js')
+import assert from 'node:assert';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import util from 'node:util';
+import eol from 'eol';
+import expectedOutput from './fixture/expectedOutput.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 const scriptPath = path
 	.resolve(__dirname, '..', 'index.js')

--- a/test/extractAuthor.test.js
+++ b/test/extractAuthor.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const extractAuthor = require('../lib/extractAuthor.js')
+import assert from 'node:assert';
+import extractAuthor from '../lib/extractAuthor.js';
 
 describe('extractAuthor', function() {
 	it('if its a string', function() {

--- a/test/extractLicense.test.js
+++ b/test/extractLicense.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const extractLicense = require('../lib/extractLicense.js')
+import assert from 'node:assert';
+import extractLicense from '../lib/extractLicense.js';
 
 describe('extractLicense', function() {
 	it('if it is a string', function() {

--- a/test/extractLink.test.js
+++ b/test/extractLink.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const extractLink = require('../lib/extractLink.js')
+import assert from 'node:assert';
+import extractLink from '../lib/extractLink.js';
 
 describe('extractLink', function() {
 	it('extracts the repository link if its there', function() {

--- a/test/fixture/expectedOutput.js
+++ b/test/fixture/expectedOutput.js
@@ -1,7 +1,9 @@
-const got = require('got')
-const semver = require('semver')
-const debug = require('debug')('license-report:addRemoteVersion')
-const config = require('../../lib/config.js')
+import got from 'got';
+import semver from 'semver';
+import createDebugMessages from 'debug';
+import config from '../../lib/config.js';
+
+const debug = createDebugMessages('license-report:expectedOutput');
 
 /*
 	get latest version from registry and add it to the entry in the expectedData;
@@ -17,7 +19,8 @@ async function addRemoteVersion(dependency) {
 	debug('addRemoteVersion - REQUEST %s', uri)
 
 	const options = {
-		retry: config.httpRetryOptions.maxAttempts,
+		retry: config.httpRetryOptions,
+		timeout: config.httpTimeoutOptions,
 		hooks: {
 			beforeRetry: [
 				(options, error, retryCount) => {
@@ -54,7 +57,7 @@ async function addRemoteVersion(dependency) {
  * Add remoteVersion to objects in array of expectedData
  * @param {[object]} expectedData - array with expected data containing placeholders for remote versions
  */
-module.exports.addRemoteVersionsToExpectedData = async (expectedData)  => {
+async function addRemoteVersionsToExpectedData(expectedData) {
 	await Promise.all(expectedData.map(async (packageData) => {
 		await addRemoteVersion(packageData)
 	}))
@@ -63,14 +66,14 @@ module.exports.addRemoteVersionsToExpectedData = async (expectedData)  => {
 /*
 	create expected value for json output
 */
-module.exports.rawDataToJson = (rawData) => {
+function rawDataToJson(rawData) {
 	return rawData
 }
 
 /*
 	create expected value for csv output
 */
-module.exports.rawDataToCsv = (expectedData, csvTemplate) => {
+function rawDataToCsv(expectedData, csvTemplate) {
 	const fieldNames = ['author', 'department', 'relatedTo', 'licensePeriod', 'material', 'licenseType', 'link', 'remoteVersion', 'installedVersion', 'definedVersion']
 	const packageNamePattern = /\[\[(.+)]]/
 	const templateLines = csvTemplate.split('\n')
@@ -98,7 +101,7 @@ module.exports.rawDataToCsv = (expectedData, csvTemplate) => {
 /*
 	create expected value for table output
 */
-module.exports.rawDataToTable = (expectedData, tableTemplate) => {
+function rawDataToTable(expectedData, tableTemplate) {
 	const columnDefinitions = {
 		author: {title: 'author', maxColumnWidth: 0},
 		department: {title: 'department', maxColumnWidth: 0},
@@ -164,7 +167,7 @@ module.exports.rawDataToTable = (expectedData, tableTemplate) => {
 /*
 	create expected value for html output
 */
-module.exports.rawDataToHtml = (expectedData, htmlTemplate) => {
+function rawDataToHtml(expectedData, htmlTemplate) {
 	const fieldNames = ['author', 'department', 'relatedTo', 'licensePeriod', 'material', 'licenseType', 'link', 'remoteVersion', 'installedVersion', 'definedVersion']
 	const packageNamePattern = /\[\[(.+)]]/
 
@@ -193,4 +196,12 @@ module.exports.rawDataToHtml = (expectedData, htmlTemplate) => {
 
 	updatedTemplate += htmlTemplate.slice(startOfRow)
 	return updatedTemplate
+}
+
+export default {
+	addRemoteVersionsToExpectedData,
+	rawDataToJson,
+	rawDataToCsv,
+	rawDataToTable,
+	rawDataToHtml
 }

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,9 +1,12 @@
-const assert = require('assert')
-const path = require('path')
-const fs = require('fs')
-const eol = require('eol')
-const config = require('../lib/config.js')
-const getFormatter = require('../lib/getFormatter.js')
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import eol from 'eol';
+import config from '../lib/config.js';
+import getFormatter from '../lib/getFormatter.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 describe('formatter for json', () => {
   it('produces a report', () => {

--- a/test/getPackageJson.test.js
+++ b/test/getPackageJson.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const nock = require('nock')
-const config = require('../lib/config')
-const getPackageDataFromRepository = require('../lib/getPackageDataFromRepository.js')
+import assert from 'node:assert';
+import nock from 'nock';
+import config from '../lib/config.js';
+import getPackageDataFromRepository from '../lib/getPackageDataFromRepository.js';
 
 /**
  * Fetching data from the (private) repository gets mocked to get independent from
@@ -11,14 +11,14 @@ const getPackageDataFromRepository = require('../lib/getPackageDataFromRepositor
 describe('getPackageDataFromRepository', function() {
 	this.timeout(20000)
 
-	let originalHttpRetry
+	let originalHttpRetryLimit
 
 	beforeEach(function() {
-		originalHttpRetry = config.httpRetryOptions.maxAttempts
+		originalHttpRetryLimit = config.httpRetryOptions.limit
   })
 
   afterEach(function() {
-		config.httpRetryOptions.maxAttempts = originalHttpRetry
+		config.httpRetryOptions.limit = originalHttpRetryLimit
 		nock.cleanAll()
   })
 
@@ -26,7 +26,7 @@ describe('getPackageDataFromRepository', function() {
 		const packageName = 'semver'
 
 		// Mock the npm private repository response
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 		const scope = nock(config.registry, {"encodedQueryParams":true})
 	  .get(`/${packageName}`)
 	  .reply(200, responses.semver)
@@ -53,18 +53,18 @@ describe('getPackageDataFromRepository with private repository', function() {
 
 	let originalConfigRegistry
 	let originalConfigNpmTokenEnvVar
-	let originalHttpRetry
+	let originalHttpRetryLimit
 
 	beforeEach(function() {
 		originalConfigRegistry = config.registry
 		originalConfigNpmTokenEnvVar = config.npmTokenEnvVar
-		originalHttpRetry = config.httpRetryOptions.maxAttempts
+		originalHttpRetryLimit = config.httpRetryOptions.limit
   })
 
   afterEach(function() {
 		config.registry = originalConfigRegistry
 		config.npmTokenEnvVar = originalConfigNpmTokenEnvVar
-		config.httpRetryOptions.maxAttempts = originalHttpRetry
+		config.httpRetryOptions.limit = originalHttpRetryLimit
 		nock.cleanAll()
   })
 
@@ -87,7 +87,7 @@ describe('getPackageDataFromRepository with private repository', function() {
 		const npmRegistry = `https://${npmRegistryHost}/`
 		config.registry = npmRegistry
 		process.env['NPM_TOKEN'] = ''
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 
 		// Mock the npm private repository response
 		const scope = nock(npmRegistry, {"encodedQueryParams":true})
@@ -114,7 +114,7 @@ describe('getPackageDataFromRepository with private repository', function() {
 		const npmToken = 'pp6j6gzcge'
 		config.registry = npmRegistry
 		process.env['NPM_TOKEN'] = npmToken
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 
 		// Mock the npm private repository response
 		const scope = nock(npmRegistry, {"encodedQueryParams":true})
@@ -143,7 +143,7 @@ describe('getPackageDataFromRepository with private repository', function() {
 		const npmToken = 'pp6j6gzcge'
 		config.registry = npmRegistry
 		process.env['NPM_TOKEN'] = npmToken
-		config.httpRetryOptions.maxAttempts = 1
+		config.httpRetryOptions.limit = 1
 
 		// Mock the npm private repository response
 		const scope = nock(npmRegistry, {"encodedQueryParams":true})


### PR DESCRIPTION
Update 'got' to v12; this requires switching license-report to esm modules and dropping support for node versions prior to Node v14 (which are all out of maintenance status by now).