### PR TITLE
fix: issue #101 (config.registry without trailing slash throws an error)

### DIFF
--- a/lib/getPackageDataFromRepository.js
+++ b/lib/getPackageDataFromRepository.js
@@ -1,5 +1,8 @@
+import path from 'node:path';
+
 import got from 'got';
 import createDebugMessages from 'debug';
+
 import config from './config.js';
 
 const debug = createDebugMessages('license-report:getPackageDataFromRepository');
@@ -10,7 +13,8 @@ const debug = createDebugMessages('license-report:getPackageDataFromRepository')
  * @returns {object} with all informations about a package
  */
 async function getPackageDataFromRepository(name) {
-	const uri = config.registry + name
+	const uri = path.join(config.registry, name)
+	// const uri = config.registry + name
 
 	debug('getPackageDataFromRepository - REQUEST %s', uri)
 

--- a/test/fixture/expectedOutput.js
+++ b/test/fixture/expectedOutput.js
@@ -1,6 +1,9 @@
+import path from 'node:path';
+
 import got from 'got';
 import semver from 'semver';
 import createDebugMessages from 'debug';
+
 import config from '../../lib/config.js';
 
 const debug = createDebugMessages('license-report:expectedOutput');
@@ -14,7 +17,7 @@ const debug = createDebugMessages('license-report:expectedOutput');
 */
 async function addRemoteVersion(dependency) {
 	dependency.remoteVersion = 'n/a'
-	let uri = config.registry + dependency.name
+	let uri = path.join(config.registry, dependency.name)
 
 	debug('addRemoteVersion - REQUEST %s', uri)
 

--- a/test/getPackageDataFromRepository.test.js
+++ b/test/getPackageDataFromRepository.test.js
@@ -10,6 +10,36 @@ import getPackageDataFromRepository from '../lib/getPackageDataFromRepository.js
  * varying data on the server and from having a real private repository.
  */
 
+describe('getPackageDataFromRepository without trailing slash in uri', function() {
+	this.timeout(20000)
+
+	let originalHttpRetryLimit
+	let originalRegistryUri
+
+	beforeEach(function() {
+		originalHttpRetryLimit = config.httpRetryOptions.limit
+		originalRegistryUri = config.registry
+  })
+
+  afterEach(function() {
+		config.httpRetryOptions.limit = originalHttpRetryLimit
+		config.registry = originalRegistryUri
+  })
+
+  it('gets the information about the package "semver" from server', async () => {
+		const packageName = 'semver'
+
+    const packageJson = await getPackageDataFromRepository('semver')
+
+		assert.strictEqual(packageJson.name, packageName)
+		assert.ok(packageJson.versions.hasOwnProperty('7.3.7'))
+		assert.ok(packageJson.versions['7.3.7'].hasOwnProperty('dist'))
+		assert.ok(packageJson.versions['7.3.7']['dist'].hasOwnProperty('tarball'))
+		assert.ok(packageJson.versions['7.3.7'].hasOwnProperty('repository'))
+		assert.ok(packageJson.versions['7.3.7']['repository'].hasOwnProperty('url'))
+  })
+})
+
 describe('getPackageDataFromRepository', function() {
 	this.timeout(20000)
 


### PR DESCRIPTION
Solves issue #101:  
If the configuration parameter `registry` does not contain a trailing slash, license-report throws an error.