### PR TITLE
fix: issue #126 - Error when no dependency is found with markdown output

### DIFF
--- a/lib/getFormatter.js
+++ b/lib/getFormatter.js
@@ -103,10 +103,14 @@ function formatAsHTML(dataAsArray, config) {
  * @returns dataAsArray formatted as a markdown table
  */
 function formatAsMarkdown(dataAsArray, config) {
-	// Respect the possibly overridden field names
-	const dataAsArrayWithRenamedFields = dataAsArray.map(row => renameRowsProperties(row, config))
-  
-	return tablemark(dataAsArrayWithRenamedFields, config.tablemarkOptions);
+	let result = ''
+	if (dataAsArray.length > 0) {
+		// Respect the possibly overridden field names
+		const dataAsArrayWithRenamedFields = dataAsArray.map(row => renameRowsProperties(row, config))
+		result = tablemark(dataAsArrayWithRenamedFields, config.tablemarkOptions)
+	}
+
+	return result
   }
 
 /**

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -39,6 +39,19 @@ const localPackagesConfigPath = path
 	.resolve(__dirname, 'fixture', 'local-packages', 'license-report-config.json')
 	.replace(/(\s+)/g, '\\$1')
 
+// test data for e2e test using package.json with empty dependencies
+const emptyDepsPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'empty-dependency-package.json')
+	.replace(/(\s+)/g, '\\$1')
+// test data for e2e test using package.json with no dependencies
+const noDepsPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'no-dependency-package.json')
+	.replace(/(\s+)/g, '\\$1')
+// test data for e2e test using package.json with no dependencies
+const subPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'sub-deps-package.json')
+	.replace(/(\s+)/g, '\\$1')
+
 const execAsPromise = util.promisify(cp.exec)
 
 let expectedData
@@ -220,6 +233,85 @@ describe('end to end test for all fields', function() {
 		const expectedLengthOfResult = 3
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+})
+
+describe('end to end test package without dependencies', function() {
+	this.timeout(50000)
+	this.slow(4000)
+
+	it('produce a json report for a package with empty dependencies', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${emptyDepsPackageJsonPath}`)
+		const result = JSON.parse(stdout)
+		const expectedResult = [];
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedResult)
+
+		assert.deepStrictEqual(result, expectedResult, `expected the output to contain no entries`)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+
+	it('produce a json report for a package without dependencies', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${noDepsPackageJsonPath}`)
+		const result = JSON.parse(stdout)
+		const expectedResult = [];
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedResult)
+
+		assert.deepStrictEqual(result, expectedResult, `expected the output to contain no entries`)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+
+	it('produce a json report for a package with sub-package without dependencies', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${subPackageJsonPath}`)
+		const result = JSON.parse(stdout)
+		const expectedResult = [   {
+			author: "Dan VerWeire, Yaniv Kessler",
+			definedVersion: "^1.0.2",
+			department: "kessler",
+			installedVersion: "1.0.2",
+			licensePeriod: "perpetual",
+			licenseType: "MIT",
+			link: "git+https://github.com/kessler/node-tableify.git",
+			material: "material",
+			name: "@kessler/tableify",
+			relatedTo: "stuff",
+			remoteVersion: "1.0.2"
+		},
+		{
+			author: "TJ Holowaychuk <tj@vision-media.ca>",
+			definedVersion: "^9.1.1",
+			department: "kessler",
+			installedVersion: "9.1.2",
+			licensePeriod: "perpetual",
+			licenseType: "MIT",
+			link: "git+https://github.com/mochajs/mocha.git",
+			material: "material",
+			name: "mocha",
+			relatedTo: "stuff",
+			remoteVersion: "9.2.2"
+		}
+	];
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedResult)
+
+		assert.deepStrictEqual(result, expectedResult, `expected the output to contain no entries`)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+
+	it('produce a markdown report for a package with empty dependencies', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${emptyDepsPackageJsonPath} --output=markdown`)
+		const result = stdout
+		const expectedResult = '\n'
+
+		assert.deepStrictEqual(result, expectedResult, `expected the output to contain no entries`)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+
+	it('produce a markdown report for a package with no dependencies', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${noDepsPackageJsonPath} --output=markdown`)
+		const result = stdout
+		const expectedResult = '\n'
+
+		assert.deepStrictEqual(result, expectedResult, `expected the output to contain no entries`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
 	})
 })

--- a/test/fixture/dependencies/empty-dependency-package.json
+++ b/test/fixture/dependencies/empty-dependency-package.json
@@ -1,0 +1,12 @@
+{
+  "name": "license-report",
+  "description": "package.json for e2e tests with empty dependencies",
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "optionalDependencies": {
+  },
+  "peerDependencies": {
+  }
+}

--- a/test/fixture/dependencies/no-dependency-package.json
+++ b/test/fixture/dependencies/no-dependency-package.json
@@ -1,0 +1,4 @@
+{
+  "name": "license-report",
+  "description": "package.json for e2e tests without dependencies"
+}

--- a/test/fixture/dependencies/node_modules/@kessler/tableify/package.json
+++ b/test/fixture/dependencies/node_modules/@kessler/tableify/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@kessler/tableify",
+  "description": "Create HTML tables from Javascript Objects",
+  "version": "1.0.2",
+  "license": "MIT",
+  "author": "Dan VerWeire, Yaniv Kessler"
+}

--- a/test/fixture/dependencies/node_modules/mocha/package.json
+++ b/test/fixture/dependencies/node_modules/mocha/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mocha",
+  "description": "simple, flexible, fun test framework",
+  "version": "9.1.2",
+  "license": "MIT",
+  "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "dependencies": {}
+}

--- a/test/fixture/dependencies/sub-deps-package.json
+++ b/test/fixture/dependencies/sub-deps-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "license-report",
+  "description": "package.json for e2e tests without dependencies in sub-package",
+  "dependencies": {
+    "@kessler/tableify": "^1.0.2"
+  },
+  "devDependencies": {
+    "mocha": "^9.1.1"
+  }
+}

--- a/test/getDependencies.test.js
+++ b/test/getDependencies.test.js
@@ -14,6 +14,15 @@ const packageJsonPath = path
 	.resolve(__dirname, 'fixture', 'default-fields', 'package.json')
 	.replace(/(\s+)/g, '\\$1')
 
+	// test data for test using package.json with empty dependencies
+const emptyDepsPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'empty-dependency-package.json')
+	.replace(/(\s+)/g, '\\$1')
+// test data for test using package.json with no dependencies
+const noDepsPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'no-dependency-package.json')
+	.replace(/(\s+)/g, '\\$1')
+
 describe('getDependencies', () => {
 	let packageJson
 
@@ -66,5 +75,19 @@ describe('getDependencies', () => {
 
 		assert.strictEqual(depsIndex.length, 1)
 		assert.strictEqual(depsIndex[0].fullName, 'lodash')
+	})
+
+	it('adds dependencies to output for empty dependencies property', () => {
+		const exclusions = []
+    let depsIndex = getDependencies(emptyDepsPackageJsonPath, exclusions)
+
+		assert.strictEqual(depsIndex.length, 0)
+	})
+
+	it('adds all dependency to output for missing dependencies properties', () => {
+		const exclusions = []
+    let depsIndex = getDependencies(noDepsPackageJsonPath, exclusions)
+
+		assert.strictEqual(depsIndex.length, 0)
 	})
 });


### PR DESCRIPTION
Fixes error thrown when generating a markdown report for a package.json that does not contain any dependencies (issue #126).