### PR TITLE
allow package-lock.json traversing

### DIFF
--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -13,6 +13,12 @@ describe('addPackagesToIndex', function() {
 
 		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '*', scope: undefined, alias: '' }])
 	})
+	
+    	it('adds a package to the index - object', function() {
+        	addPackagesToIndex({ "foo": {"version": "*"} }, index)
+
+		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '*', scope: undefined, alias: '' }])
+	})
 
 	it('adds a scoped package to the index', function() {
 		addPackagesToIndex({ "@bar/foo": "*" }, index)


### PR DESCRIPTION
Allows providing `package-lock.json`  as `--package` parameter. This allows output of all dependencies, including transient ones.