### PR TITLE
allow package-lock.json traversing

### DIFF
--- a/lib/addPackagesToIndex.js
+++ b/lib/addPackagesToIndex.js
@@ -18,7 +18,8 @@ function addPackagesToIndex(packages, packageIndex, exclusions) {
 		let name = key
 		let fullName = key
 		let alias = ''
-		let version = packages[key]
+		// if `packages[key]` is of `object` type, we passed in `package-lock.json` file as `--package` parameter
+		let version = typeof packages[key] === 'object' ? packages[key].version : packages[key]
 		if (version.startsWith('npm:')) {
 			alias = fullName
 			const aliasBase = version.substring(4)

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -13,6 +13,12 @@ describe('addPackagesToIndex', function() {
 
 		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '*', scope: undefined, alias: '' }])
 	})
+	
+    	it('adds a package to the index - object', function() {
+        	addPackagesToIndex({ "foo": {"version": "*"} }, index)
+
+		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '*', scope: undefined, alias: '' }])
+	})
 
 	it('adds a scoped package to the index', function() {
 		addPackagesToIndex({ "@bar/foo": "*" }, index)


### PR DESCRIPTION
Allows providing `package-lock.json` as `--package` parameter. This allows output of all dependencies, including transient ones.