### PR TITLE
fix: enable selecting a single field in the output via 'fields' configuration element

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ When using the 'hcat' package to open the result in a browser, this package must
 ### Select fields for output:
 If only a few fields are required in the output, the easiest way of selecting the fields is via --fields command line arguments.
 
-There must be at least 2 --fields options ('name' and 'installedVersion'), otherwise license-report
-will throw an error.
-
 ```
 # set options with command line arguments
 license-report --output=csv --fields=name --fields=installedVersion

--- a/index.js
+++ b/index.js
@@ -45,12 +45,13 @@ const debug = createDebugMessages('license-report');
     // Get a list of all the dependencies we want information about.
     const inclusions = util.isNullOrUndefined(config.only) ? null : config.only.split(',')
     const exclusions = Array.isArray(config.exclude) ? config.exclude : [config.exclude]
+    const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
     let depsIndex = getDependencies(packageJson, exclusions, inclusions)
 
     const projectRootPath = path.dirname(resolvedPackageJson)
     const packagesData = await Promise.all(
       depsIndex.map(async (element) => {
-        const localDataForPackage = await addLocalPackageData(element, projectRootPath, config.fields)
+        const localDataForPackage = await addLocalPackageData(element, projectRootPath, fieldsList)
         const completeDataForPackage = await addPackageDataFromRepository(localDataForPackage)
         return packageDataToReportData(completeDataForPackage, config)
       })

--- a/lib/getFormatter.js
+++ b/lib/getFormatter.js
@@ -20,14 +20,15 @@ function formatAsJsonString(dataAsArray, config) {
  * @returns dataAsArray formatted as table string
  */
 function formatAsTable(dataAsArray, config) {
+	const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
 	let data = arrayOfObjectsToArrayOfArrays(dataAsArray)
 	let labels = []
 	let lines = []
 
 	// create a labels array and a lines array
 	// the lines will be the same length as the label's
-	for (let i = 0; i < config.fields.length; i++) {
-		let label = config[config.fields[i]].label
+	for (let i = 0; i < fieldsList.length; i++) {
+		let label = config[fieldsList[i]].label
 		labels.push(label)
 		lines.push('-'.repeat(label.length))
 	}
@@ -46,6 +47,7 @@ function formatAsTable(dataAsArray, config) {
  * @returns dataAsArray formatted as csv string
  */
 function formatAsCsv(dataAsArray, config) {
+	const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
 	let data = arrayOfObjectsToArrayOfArrays(dataAsArray)
 	let csv = []
 	const delimiter = config.delimiter
@@ -54,8 +56,8 @@ function formatAsCsv(dataAsArray, config) {
 	if (config.csvHeaders) {
 		let labels = []
 		// create a labels array and a lines array
-		for (let i = 0; i < config.fields.length; i++) {
-			labels.push(config[config.fields[i]].label)
+		for (let i = 0; i < fieldsList.length; i++) {
+			labels.push(config[fieldsList[i]].label)
 		}
 		csv.push(labels.join(delimiter))
 	}
@@ -177,9 +179,10 @@ function renameProp(oldProp, newProp, { [oldProp]: old, ...others }) {
  * @param {object} config - configuration object
  */
 function renameRowsProperties(row, config) {
+	const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
 	let renamedRow = row
-	for (let i = config.fields.length - 1; i >= 0; i--) {
-		const fieldname = config.fields[i];
+	for (let i = fieldsList.length - 1; i >= 0; i--) {
+		const fieldname = fieldsList[i];
 		renamedRow = renameProp(fieldname, config[fieldname].label, renamedRow)
 	}
 	return renamedRow
@@ -194,10 +197,11 @@ function renameRowsProperties(row, config) {
  * @returns {object} dummy entry with one space as value
  */
 function dataArrayWithEmptyRow(config) {
+	const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
 	let emptyRow = {}
 	// create an array with 1 line of empty entries, to display empty table with header
-	for (let i = config.fields.length - 1; i >= 0; i--) {
-		let label = config[config.fields[i]].label
+	for (let i = fieldsList.length - 1; i >= 0; i--) {
+		let label = config[fieldsList[i]].label
 		emptyRow[label] = ' '
 	}
 	return emptyRow

--- a/lib/packageDataToReportData.js
+++ b/lib/packageDataToReportData.js
@@ -8,10 +8,11 @@
  * @returns object with all fields listed in config.fields
  */
 function packageDataToReportData(packageData, config) {
+	const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
 	let finalData = {}
 
 	// create only fields specified in the config
-	config.fields.forEach(fieldName => {
+	fieldsList.forEach(fieldName => {
 		if ((fieldName in packageData)) {
 			finalData[fieldName] = packageData[fieldName]
 		} else {

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -242,6 +242,25 @@ describe('end to end test for all fields', function() {
 	})
 })
 
+describe('end to end test for single field', function() {
+	this.timeout(60000)
+	this.slow(5000)
+
+	beforeEach(async  () => {
+		expectedData = EXPECTED_SINGLE_FIELD_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedData)
+  })
+
+	it('produce a json report with a single field', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --fields=name`)
+		const result = JSON.parse(stdout)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+
+		assert.deepStrictEqual(result, expectedJsonResult)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	})
+})
+
 describe('end to end test package without dependencies', function() {
 	this.timeout(50000)
 	this.slow(4000)
@@ -405,6 +424,22 @@ const EXPECTED_DEFAULT_FIELDS_RAW_DATA = [
 		remoteVersion: '_VERSION_',
 		installedVersion: '7.5.4',
 		definedVersion: '^7.5.1'
+	},	
+]
+
+// raw data we use to generate the expected results for single field test
+const EXPECTED_SINGLE_FIELD_RAW_DATA = [
+	{
+		name: '@kessler/tableify'
+	},
+	{
+		name: 'mocha'
+	},		
+	{
+		name: 'lodash'
+	},	
+	{
+		name: 'semver'
 	},	
 ]
 


### PR DESCRIPTION
Enable selecting a single field for output with the configuration element 'fields'.
Until now, you have to select at least 2 fields, otherwise license-report will throw an error.