### PR TITLE
add regex support for package exlusions - solves #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ With the 'exclude' option, single packages can be excluded from the output.
 license-report --exclude=async --exclude=rc
 ```
 
+Using the 'excludeRegex' option, packages can be excluded from the output using a regular expression.
+```
+license-report --excludeRegex=@mycompany\/.*
+```
+
 ## Format output
 
 ### Markdown Options
@@ -211,6 +216,7 @@ Fields with data of the installed packages:
 
 &nbsp;   
 Fields with data set in the configuration of license-report:
+
 | fieldname | column title | set value |
 |--|---|---|
 | department | department | --department.value=kessler |

--- a/index.js
+++ b/index.js
@@ -45,8 +45,16 @@ const debug = createDebugMessages('license-report');
     // Get a list of all the dependencies we want information about.
     const inclusions = util.isNullOrUndefined(config.only) ? null : config.only.split(',')
     const exclusions = Array.isArray(config.exclude) ? config.exclude : [config.exclude]
+    let exclusionRegexp
+    if ((config.excludeRegex !== undefined)  && (typeof config.excludeRegex === 'string') && (config.excludeRegex !== '')) {
+      try {
+        exclusionRegexp = new RegExp(config.excludeRegex, 'i')
+      } catch (error) {
+        exclusionRegexp = undefined
+      }
+    }
     const fieldsList = Array.isArray(config.fields) ? config.fields : [config.fields]
-    let depsIndex = getDependencies(packageJson, exclusions, inclusions)
+    let depsIndex = getDependencies(packageJson, exclusions, inclusions, exclusionRegexp)
 
     const projectRootPath = path.dirname(resolvedPackageJson)
     const packagesData = await Promise.all(

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const debug = createDebugMessages('license-report');
       try {
         exclusionRegexp = new RegExp(config.excludeRegex, 'i')
       } catch (error) {
+        console.error(error.message)
         exclusionRegexp = undefined
       }
     }

--- a/lib/addPackagesToIndex.js
+++ b/lib/addPackagesToIndex.js
@@ -5,13 +5,14 @@
  * @param {object} packages - object with dependencies from a package.json (e.g. value of 'dependencies' or 'devDependencies')
  * @param {object[]} packageIndex - array, the information about the packages are added to ('package index') - input/output value!
  * @param {string[]} exclusions - exclusions list from config object
+ * @param {object} exclusionRegex - RegExp object created from config.excludeRegex defining additional excluded packages
  */
-function addPackagesToIndex(packages, packageIndex, exclusions) {
+function addPackagesToIndex(packages, packageIndex, exclusions, exclusionRegex) {
 	exclusions = exclusions || []
 
 	// iterate over packages and prepare urls before I call the registry
 	for (let key in packages) {
-		if (exclusions.indexOf(key) !== -1) {
+		if ((exclusions.indexOf(key) !== -1) || exclusionRegex?.test(key)) {
 			continue
 		}
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,6 +61,12 @@ export default rc('license-report', {
 	exclude: [],
 
 	/*
+		a regular expression of package names that will be excluded from the report;
+		the regex string must not start or end with a forward slash (e.g. '^@bepo65\/.*')
+	*/
+	excludeRegex: '',
+
+	/*
 		fields participating in the report and their order
 	*/
 	fields: [

--- a/lib/getDependencies.js
+++ b/lib/getDependencies.js
@@ -10,25 +10,26 @@ import util from './util.js';
  * @param {object} packageJson - content of package.json
  * @param {string[]} exclusions - array of package names to be excluded (from config.exclude)
  * @param {string[]} inclusions - array of strings of types of dependencies to be included (from config.only)
+ * @param {string[]} exclusionRegex - RegExp object created from config.excludeRegex defining additional excluded packages
  * @return {object[]} with dependencies
  */
-function getDependencies(packageJson, exclusions, inclusions) {
+function getDependencies(packageJson, exclusions, inclusions, exclusionRegex) {
   let depsIndex = []
   const noDepsTypeDefined = util.isNullOrUndefined(inclusions) || !Array.isArray(inclusions) || (inclusions.length === 0)
   if ((noDepsTypeDefined || (inclusions.indexOf('prod') > -1)) && (packageJson.dependencies !== undefined)) {
-    addPackagesToIndex(packageJson.dependencies, depsIndex, exclusions);
+    addPackagesToIndex(packageJson.dependencies, depsIndex, exclusions, exclusionRegex);
   }
 
   if ((noDepsTypeDefined || (inclusions.indexOf('dev') > -1)) && (packageJson.devDependencies !== undefined)) {
-    addPackagesToIndex(packageJson.devDependencies, depsIndex, exclusions);
+    addPackagesToIndex(packageJson.devDependencies, depsIndex, exclusions, exclusionRegex);
   }
 
   if ((noDepsTypeDefined || (inclusions.indexOf('peer') > -1)) && (packageJson.peerDependencies !== undefined)) {
-    addPackagesToIndex(packageJson.peerDependencies, depsIndex, exclusions);
+    addPackagesToIndex(packageJson.peerDependencies, depsIndex, exclusions, exclusionRegex);
   }
 
   if ((noDepsTypeDefined || (inclusions.indexOf('opt') > -1)) && (packageJson.optionalDependencies !== undefined)) {
-    addPackagesToIndex(packageJson.optionalDependencies, depsIndex, exclusions);
+    addPackagesToIndex(packageJson.optionalDependencies, depsIndex, exclusions, exclusionRegex);
   }
 
   return depsIndex

--- a/test/addPackagesToIndex.test.js
+++ b/test/addPackagesToIndex.test.js
@@ -42,13 +42,39 @@ describe('addPackagesToIndex', () => {
 		])
 	})
 
-	it('excludes package names that are specified in the exclusion parameter, currently this is a broad exclusion, i.e all packages with specified names are excluded', () => {
+	it('does not add excluded package to the index - single word exclude', () => {
+		const exclude = 'semver'
+		addPackagesToIndex({ "semver": "1.2.3" }, index, exclude)
+		addPackagesToIndex({
+			"@bar/foo": "*",
+			"foo": "1.1.1"
+		}, index, exclude)
+		const expectedResult = [
+			{ fullName: '@bar/foo', name: 'foo', version: '*', scope: "bar", alias: '' },
+			{ fullName: 'foo', name: 'foo', version: '1.1.1', scope: undefined, alias: '' }
+		]
+
+		assert.deepStrictEqual(index, expectedResult)
+	});
+
+	it('does not add excluded package to the index - array of excludes', () => {
 		const exclude = ['@bar/foo']
 		addPackagesToIndex({ "@bar/foo": "1.2.3" }, index, exclude)
 		addPackagesToIndex({
 			"@bar/foo": "*",
 			"foo": "1.1.1"
 		}, index, exclude)
+
+		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '1.1.1', scope: undefined, alias: '' }])
+	})
+
+	it('does not add excluded package to the index - excludeRegex', () => {
+		const excludeRegexp = new RegExp('@bar\/f.*')
+		addPackagesToIndex({ "@bar/foo": "1.2.3" }, index, undefined, excludeRegexp)
+		addPackagesToIndex({
+			"@bar/foo": "*",
+			"foo": "1.1.1"
+		}, index, undefined, excludeRegexp)
 
 		assert.deepStrictEqual(index, [{ fullName: 'foo', name: 'foo', version: '1.1.1', scope: undefined, alias: '' }])
 	})

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -48,32 +48,39 @@ const localPackagesConfigPath = path
 const emptyDepsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'dependencies', 'empty-dependency-package.json')
 	.replace(/(\s+)/g, '\\$1')
+
 // test data for e2e test using package.json with no dependencies
 const noDepsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'dependencies', 'no-dependency-package.json')
 	.replace(/(\s+)/g, '\\$1')
+
 // test data for e2e test using package.json with no dependencies
 const subPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'dependencies', 'sub-deps-package.json')
 	.replace(/(\s+)/g, '\\$1')
 
+// test data for e2e test with exclusions using package.json with multiple dependencies
+const multiPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'multi-deps-package.json')
+	.replace(/(\s+)/g, '\\$1')
+
 const execAsPromise = util.promisify(cp.exec)
 
-let expectedData
+let expectedDataBase
 
 describe('end to end test for default fields', function() {
 	this.timeout(60000)
 	this.slow(5000)
 
 	beforeEach(async  () => {
-		expectedData = EXPECTED_DEFAULT_FIELDS_RAW_DATA.slice(0)
-		await expectedOutput.addRemoteVersionsToExpectedData(expectedData)
+		expectedDataBase = EXPECTED_DEFAULT_FIELDS_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedDataBase)
   })
 
 	it('produce a json report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath}`)
 		const result = JSON.parse(stdout)
-		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
 
 		assert.deepStrictEqual(result, expectedJsonResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -81,7 +88,7 @@ describe('end to end test for default fields', function() {
 
 	it('produce a table report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --output=table`)
-		const expectedTableResult = expectedOutput.rawDataToTable(expectedData, EXPECTED_TABLE_TEMPLATE)
+		const expectedTableResult = expectedOutput.rawDataToTable(expectedDataBase, EXPECTED_TABLE_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedTableResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -89,7 +96,7 @@ describe('end to end test for default fields', function() {
 
 	it('produce a csv report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --output=csv --csvHeaders`)
-		const expectedCsvResult = expectedOutput.rawDataToCsv(expectedData, EXPECTED_CSV_TEMPLATE)
+		const expectedCsvResult = expectedOutput.rawDataToCsv(expectedDataBase, EXPECTED_CSV_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedCsvResult)
 		assert.strictEqual(stderr, 'Warning: field contains delimiter; value: \"Dan VerWeire, Yaniv Kessler\"\n')
@@ -99,7 +106,7 @@ describe('end to end test for default fields', function() {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --output=html`)
 		const actualResult = eol.auto(stdout)
 		const expectedHtmlTemplate = eol.auto(fs.readFileSync(path.join(__dirname, 'fixture', 'expectedOutput.e2e.html'), 'utf8'))
-		const expectedHtmlResult = expectedOutput.rawDataToHtml(expectedData, expectedHtmlTemplate)
+		const expectedHtmlResult = expectedOutput.rawDataToHtml(expectedDataBase, expectedHtmlTemplate)
 
 		assert.strictEqual(actualResult, expectedHtmlResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -107,7 +114,7 @@ describe('end to end test for default fields', function() {
 
 	it('produce a markdown table report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --output=markdown`)
-		const expectedMarkdownTableResult = expectedOutput.rawDataToMarkdown(expectedData, EXPECTED_MARKDOWN_TABLE_TEMPLATE)
+		const expectedMarkdownTableResult = expectedOutput.rawDataToMarkdown(expectedDataBase, EXPECTED_MARKDOWN_TABLE_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedMarkdownTableResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -119,14 +126,14 @@ describe('end to end test for default fields in monorepo', function() {
 	this.slow(5000)
 
 	beforeEach(async  () => {
-		expectedData = EXPECTED_DEFAULT_FIELDS_RAW_DATA.slice(0)
-		await expectedOutput.addRemoteVersionsToExpectedData(expectedData)
+		expectedDataBase = EXPECTED_DEFAULT_FIELDS_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedDataBase)
   })
 
 	it('produce a json report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsMonorepoPackageJsonPath}`)
 		const result = JSON.parse(stdout)
-		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
 
 		assert.deepStrictEqual(result, expectedJsonResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -134,7 +141,7 @@ describe('end to end test for default fields in monorepo', function() {
 
 	it('produce a table report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsMonorepoPackageJsonPath} --output=table`)
-		const expectedTableResult = expectedOutput.rawDataToTable(expectedData, EXPECTED_TABLE_TEMPLATE)
+		const expectedTableResult = expectedOutput.rawDataToTable(expectedDataBase, EXPECTED_TABLE_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedTableResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -142,7 +149,7 @@ describe('end to end test for default fields in monorepo', function() {
 
 	it('produce a csv report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsMonorepoPackageJsonPath} --output=csv --csvHeaders`)
-		const expectedCsvResult = expectedOutput.rawDataToCsv(expectedData, EXPECTED_CSV_TEMPLATE)
+		const expectedCsvResult = expectedOutput.rawDataToCsv(expectedDataBase, EXPECTED_CSV_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedCsvResult)
 		assert.strictEqual(stderr, 'Warning: field contains delimiter; value: \"Dan VerWeire, Yaniv Kessler\"\n')
@@ -152,7 +159,7 @@ describe('end to end test for default fields in monorepo', function() {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsMonorepoPackageJsonPath} --output=html`)
 		const actualResult = eol.auto(stdout)
 		const expectedHtmlTemplate = eol.auto(fs.readFileSync(path.join(__dirname, 'fixture', 'expectedOutput.e2e.html'), 'utf8'))
-		const expectedHtmlResult = expectedOutput.rawDataToHtml(expectedData, expectedHtmlTemplate)
+		const expectedHtmlResult = expectedOutput.rawDataToHtml(expectedDataBase, expectedHtmlTemplate)
 
 		assert.strictEqual(actualResult, expectedHtmlResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -160,7 +167,7 @@ describe('end to end test for default fields in monorepo', function() {
 
 	it('produce a markdown table report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsMonorepoPackageJsonPath} --output=markdown`)
-		const expectedMarkdownTableResult = expectedOutput.rawDataToMarkdown(expectedData, EXPECTED_MARKDOWN_TABLE_TEMPLATE)
+		const expectedMarkdownTableResult = expectedOutput.rawDataToMarkdown(expectedDataBase, EXPECTED_MARKDOWN_TABLE_TEMPLATE)
 
 		assert.strictEqual(stdout, expectedMarkdownTableResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -172,14 +179,14 @@ describe('end to end test for local packages', function() {
 	this.slow(4000)
 
 	beforeEach(async  () => {
-		expectedData = EXPECTED_LOCAL_PACKAGES_RAW_DATA.slice(0)
-		await expectedOutput.addRemoteVersionsToExpectedData(expectedData)
+		expectedDataBase = EXPECTED_LOCAL_PACKAGES_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedDataBase)
   })
 
 	it('produce a json report', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${localPackagesPackageJsonPath} --config=${localPackagesConfigPath}`)
 		const result = JSON.parse(stdout)
-		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
 
 		assert.deepStrictEqual(result, expectedJsonResult)
 	})
@@ -247,14 +254,14 @@ describe('end to end test for single field', function() {
 	this.slow(5000)
 
 	beforeEach(async  () => {
-		expectedData = EXPECTED_SINGLE_FIELD_RAW_DATA.slice(0)
-		await expectedOutput.addRemoteVersionsToExpectedData(expectedData)
+		expectedDataBase = EXPECTED_SINGLE_FIELD_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedDataBase)
   })
 
 	it('produce a json report with a single field', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${defaultFieldsPackageJsonPath} --fields=name`)
 		const result = JSON.parse(stdout)
-		const expectedJsonResult = expectedOutput.rawDataToJson(expectedData)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
 
 		assert.deepStrictEqual(result, expectedJsonResult)
 		assert.strictEqual(stderr, '', 'expected no warnings')
@@ -369,6 +376,47 @@ describe('end to end test for custom fields', function() {
 		assert.deepStrictEqual(result, expectedResult, `expected the output to contain all the configured fields`)
 		assert.strictEqual(stderr, '', 'expected no warnings')
 	})
+})
+
+// TODO e2e for exclusions
+describe('end to end test with exclusions', function() {
+	this.timeout(50000)
+	this.slow(4000)
+
+	beforeEach(async  () => {
+		expectedDataBase = EXPECTED_MULTI_DEPS_RAW_DATA.slice(0)
+		await expectedOutput.addRemoteVersionsToExpectedData(expectedDataBase)
+  })
+
+	it('produce a report excluding a single package', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${multiPackageJsonPath} --exclude=tablemark --fields=name --fields=installedVersion`)
+		const result = JSON.parse(stdout)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
+		expectedJsonResult.splice(1, 1)
+
+		assert.deepStrictEqual(result, expectedJsonResult)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	});
+
+	it('produce a report excluding an array of packages', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${multiPackageJsonPath} --exclude=tablemark --exclude=text-table --fields=name --fields=installedVersion`)
+		const result = JSON.parse(stdout)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
+		expectedJsonResult.splice(1, 2)
+
+		assert.deepStrictEqual(result, expectedJsonResult)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	});
+
+	it('produce a report excluding packages with a regular expression', async () => {
+		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${multiPackageJsonPath} --excludeRegex=@commitlint\/.* --fields=name --fields=installedVersion`)
+		const result = JSON.parse(stdout)
+		const expectedJsonResult = expectedOutput.rawDataToJson(expectedDataBase)
+		expectedJsonResult.splice(3, 2)
+
+		assert.deepStrictEqual(result, expectedJsonResult)
+		assert.strictEqual(stderr, '', 'expected no warnings')
+	});
 })
 
 // raw data we use to generate the expected results for default fields test
@@ -542,3 +590,30 @@ const EXPECTED_MARKDOWN_TABLE_TEMPLATE =
 | {{department}}    | {{relatedTo}}      | [[semver]]            | {{licensePeriod}}      | {{material}}              | {{licenseType}}          | {{link}}       | {{remoteVersion}}          | {{installedVersion}}             | {{definedVersion}}          | {{author}}                                     |
 
 `
+
+const EXPECTED_MULTI_DEPS_RAW_DATA = [
+  {
+    name: "@kessler/tableify",
+    installedVersion: "1.0.2",
+  },
+  {
+    name: "tablemark",
+    installedVersion: "3.0.0",
+  },
+  {
+    name: "text-table",
+    installedVersion: "0.2.0",
+  },
+  {
+    name: "@commitlint/cli",
+    installedVersion: "17.7.1",
+  },
+  {
+    name: "@commitlint/config-conventional",
+    installedVersion: "17.7.0",
+  },
+  {
+    name: "mocha",
+    installedVersion: "9.1.2",
+  },
+]

--- a/test/fixture/dependencies/multi-deps-package.json
+++ b/test/fixture/dependencies/multi-deps-package.json
@@ -1,0 +1,14 @@
+{
+  "name": "license-report",
+  "description": "package.json for tests with multiple dependencies",
+  "dependencies": {
+    "@kessler/tableify": "^1.0.2",
+    "tablemark": "^3.0.0",
+    "text-table": "~0.2.0"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^17.7.1",
+    "@commitlint/config-conventional": "^17.7.0",
+    "mocha": "^9.1.1"
+  }
+}

--- a/test/fixture/dependencies/node_modules/@commitlint/cli/package.json
+++ b/test/fixture/dependencies/node_modules/@commitlint/cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@commitlint/cli",
+  "description": "Lint your commit messages",
+  "version": "17.7.1",
+  "author": {
+    "name": "Mario Nebl",
+    "email": "hello@herebecode.com"
+  },
+  "license": "MIT",
+  "dependencies": { }
+}

--- a/test/getDependencies.test.js
+++ b/test/getDependencies.test.js
@@ -14,13 +14,19 @@ const packageJsonPath = path
 	.resolve(__dirname, 'fixture', 'default-fields', 'package.json')
 	.replace(/(\s+)/g, '\\$1')
 
-	// test data for test using package.json with empty dependencies
+// test data for test using package.json with empty dependencies
 const emptyDepsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'dependencies', 'empty-dependency-package.json')
 	.replace(/(\s+)/g, '\\$1')
+
 // test data for test using package.json with no dependencies
 const noDepsPackageJsonPath = path
 	.resolve(__dirname, 'fixture', 'dependencies', 'no-dependency-package.json')
+	.replace(/(\s+)/g, '\\$1')
+
+// test data for test using package.json with multiple dependencies
+const multiDepsPackageJsonPath = path
+	.resolve(__dirname, 'fixture', 'dependencies', 'multi-deps-package.json')
 	.replace(/(\s+)/g, '\\$1')
 
 describe('getDependencies', () => {
@@ -77,17 +83,69 @@ describe('getDependencies', () => {
 		assert.strictEqual(depsIndex[0].fullName, 'lodash')
 	})
 
-	it('adds dependencies to output for empty dependencies property', () => {
+	it('adds dependencies to output for empty dependencies property', async () => {
 		const exclusions = []
-    let depsIndex = getDependencies(emptyDepsPackageJsonPath, exclusions)
+		packageJson = await util.readJson(emptyDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusions)
 
 		assert.strictEqual(depsIndex.length, 0)
 	})
 
-	it('adds all dependency to output for missing dependencies properties', () => {
+	it('adds all dependencies to output for missing dependencies properties', async () => {
 		const exclusions = []
-    let depsIndex = getDependencies(noDepsPackageJsonPath, exclusions)
+		packageJson = await util.readJson(noDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusions)
 
 		assert.strictEqual(depsIndex.length, 0)
 	})
+
+	it('adds multiple dependencies to output', async () => {
+		const exclusions = []
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusions)
+
+		assert.strictEqual(depsIndex.length, 6)
+	});
+
+	it('adds multiple dependencies to output with single word exclude', async () => {
+		const exclusion = 'tablemark'
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusion)
+
+		assert.strictEqual(depsIndex.length, 5)
+	});
+
+	it('adds multiple dependencies to output with array of excludes', async () => {
+		const exclusions = ['tablemark', 'text-table']
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusions)
+
+		assert.strictEqual(depsIndex.length, 4)
+	});
+
+	it('adds multiple dependencies to output with excludeRegex', async () => {
+		const exclusionRegex = new RegExp('^@commitlint\/.*', 'i')
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, undefined, undefined, exclusionRegex)
+
+		assert.strictEqual(depsIndex.length, 4)
+	});
+
+	it('adds multiple dependencies to output with single word exclude and excludeRegex', async () => {
+		const exclusion = 'tablemark'
+		const exclusionRegex = new RegExp('^@commitlint\/.*', 'i')
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusion, undefined, exclusionRegex)
+
+		assert.strictEqual(depsIndex.length, 3)
+	});
+
+	it('adds multiple dependencies to output with array of excludes and excludeRegex', async () => {
+		const exclusions = ['tablemark', 'text-table']
+		const exclusionRegex = new RegExp('^@commitlint\/.*', 'i')
+		packageJson = await util.readJson(multiDepsPackageJsonPath)
+    let depsIndex = getDependencies(packageJson, exclusions, undefined, exclusionRegex)
+
+		assert.strictEqual(depsIndex.length, 2)
+	});
 });


### PR DESCRIPTION
Add regex support for package exlusions. The configuration now has a property 'excludeRegex', which can be used to exclude packages by using a regular expression selecting the names of the packages to exclude - wildcards are allowd.